### PR TITLE
Hotfix: ingest reliability + lap-by-lap driverId match

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -21,10 +21,13 @@ concurrency:
 jobs:
   ingest:
     runs-on: ubuntu-latest
-    # Real work: dump apply ~45s on Neon + lap-times backfill ~1-3min + setup
-    # ~30s ≈ 5min typical. 15 gives a 3× ceiling for Jolpica slowness without
-    # letting a stuck job idle the whole free-tier minute budget.
-    timeout-minutes: 15
+    # Real work: dump apply ~45s on Neon + lap-times backfill + setup. Lap
+    # backfill is now governed by Jolpica's 500/hour sustained rate cap (see
+    # packages/site/src/api/ingest/fetchJolpicaLaps.ts) — a saturated run that
+    # hits the hourly window then sleeps must be allowed to complete or it
+    # leaves rows half-ingested. 60 min lets us sleep up to one full Jolpica
+    # hour after burst exhaustion while still bounded for free-tier safety.
+    timeout-minutes: 60
     env:
       # All ${{ ... }} substitutions are bound to env vars (never inlined into
       # `run:` commands) so untrusted workflow_dispatch inputs can't shell-inject.

--- a/packages/site/src/api/ingest/fetchJolpicaLaps.ts
+++ b/packages/site/src/api/ingest/fetchJolpicaLaps.ts
@@ -3,46 +3,112 @@
  *
  * Endpoint: https://api.jolpi.ca/ergast/f1/{year}/{round}/laps.json
  * Pagination: max limit=100 timings per request (server clamps anything higher).
- * Rate limits: anonymous 4 req/sec, 500 req/hour.
  *
- * Each call returns one race's worth of paginated lap timings.
+ * Rate limits (per https://github.com/jolpica/jolpica-f1/blob/main/docs/rate_limits.md):
+ *   - 4 requests/second burst (anonymous)
+ *   - 500 requests/hour sustained (anonymous)
+ *
+ * Throttle strategy:
+ *   1. Burst gate: ≥260 ms between any two requests (~3.85 req/sec, leaves
+ *      headroom under the 4/sec cap for clock drift).
+ *   2. Sliding-window hour gate: keep timestamps of the last 500 requests; if
+ *      the window is full, sleep until the oldest entry ages out. This avoids
+ *      hammering the cap and then 429-stopping the run after ~100 reqs.
+ *
+ * 429 safety net: even with both gates, if Jolpica hands us a 429 (rate-limit
+ * adjusted server-side, clock skew, etc.) we honor `Retry-After` once before
+ * propagating — the caller's outer loop converts a propagated 429 into a
+ * clean early stop.
  */
 
-const BASE = 'https://api.jolpi.ca/ergast/f1';
-const MAX_LIMIT = 100;
-const REQ_INTERVAL_MS = 260; // ~3.8 req/sec, just under the 4/sec cap
+const BASE        = 'https://api.jolpi.ca/ergast/f1';
+const MAX_LIMIT   = 100;
+const BURST_MS    = 260;       // ~3.85 req/sec, just under the 4/sec cap
+const HOUR_MS     = 3_600_000;
+const HOUR_CAP    = 500;
+const MAX_BACKOFF_S = 300;     // refuse to sleep more than 5 min on a single 429
 
 export type JolpicaLapTiming = {
 	driverId: string;
 	position: string;
-	time: string;
+	time:     string;
 };
 
 export type ParsedLap = {
-	lap: number;
+	lap:     number;
 	timings: JolpicaLapTiming[];
 };
 
-let lastRequestAt = 0;
+// Sliding window of recent request timestamps (ms). Older entries are dropped
+// every time throttle() is called.
+const requestTimestamps: number[] = [];
+
+function sleep(ms: number): Promise<void> {
+	return new Promise(r => setTimeout(r, ms));
+}
 
 async function throttle(): Promise<void> {
-	const elapsed = Date.now() - lastRequestAt;
-	if (elapsed < REQ_INTERVAL_MS) {
-		await new Promise(r => setTimeout(r, REQ_INTERVAL_MS - elapsed));
+	let now = Date.now();
+
+	// Drop entries that have aged out of the 1h window.
+	while (requestTimestamps.length && now - requestTimestamps[0] > HOUR_MS) {
+		requestTimestamps.shift();
 	}
-	lastRequestAt = Date.now();
+
+	// Burst gate.
+	const last = requestTimestamps[requestTimestamps.length - 1];
+	if (last !== undefined) {
+		const sinceLast = now - last;
+		if (sinceLast < BURST_MS) await sleep(BURST_MS - sinceLast);
+	}
+
+	// Hour gate.
+	if (requestTimestamps.length >= HOUR_CAP) {
+		const wakeAt  = requestTimestamps[0] + HOUR_MS;
+		const sleepMs = wakeAt - Date.now();
+		if (sleepMs > 0) {
+			console.warn(`[jolpica] hourly cap (${HOUR_CAP}/hr) reached — sleeping ${Math.ceil(sleepMs / 1000)}s`);
+			await sleep(sleepMs);
+			now = Date.now();
+			while (requestTimestamps.length && now - requestTimestamps[0] > HOUR_MS) {
+				requestTimestamps.shift();
+			}
+		}
+	}
+
+	requestTimestamps.push(Date.now());
 }
 
 async function fetchPage(year: number, round: number, offset: number): Promise<{total: number; laps: ParsedLap[]}> {
-	await throttle();
 	const url = `${BASE}/${year}/${round}/laps.json?limit=${MAX_LIMIT}&offset=${offset}`;
-	const res = await fetch(url);
-	if (!res.ok) {
-		throw new Error(`Jolpica ${res.status} for ${url}`);
+
+	let res: Response | null = null;
+	for (let attempt = 0; attempt < 2; attempt++) {
+		await throttle();
+		res = await fetch(url);
+
+		if (res.status !== 429) break;
+
+		// 429 safety net: honor Retry-After once, then bail.
+		const ra        = res.headers.get('retry-after') ?? '';
+		const seconds   = /^\d+$/.test(ra) ? parseInt(ra, 10) : NaN;
+		// `Retry-After` can also be an HTTP-date; if it's not a plain integer
+		// we treat it as a 60s default rather than parsing the date.
+		const backoffS  = Number.isFinite(seconds) ? seconds : 60;
+		if (backoffS > MAX_BACKOFF_S) {
+			throw new Error(`Jolpica 429 for ${url} (retry-after ${backoffS}s > ${MAX_BACKOFF_S}s cap)`);
+		}
+		console.warn(`[jolpica] 429 for ${url} — honoring Retry-After ${backoffS}s (attempt ${attempt + 1}/2)`);
+		await sleep(backoffS * 1000);
 	}
+
+	if (!res || !res.ok) {
+		throw new Error(`Jolpica ${res?.status ?? 'no-response'} for ${url}`);
+	}
+
 	const json = await res.json() as {
 		MRData: {
-			total: string;
+			total:     string;
 			RaceTable: {Races: Array<{Laps: Array<{number: string; Timings: JolpicaLapTiming[]}>}>};
 		};
 	};
@@ -61,7 +127,7 @@ async function fetchPage(year: number, round: number, offset: number): Promise<{
 export async function fetchAllLaps(year: number, round: number): Promise<ParsedLap[]> {
 	const merged = new Map<number, JolpicaLapTiming[]>();
 	let offset = 0;
-	let total = -1;
+	let total  = -1;
 
 	while (total === -1 || offset < total) {
 		const {total: t, laps} = await fetchPage(year, round, offset);
@@ -88,8 +154,8 @@ export function parseTimeToMillis(time: string): number | null {
 	if (!time) return null;
 	const m = time.match(/^(?:(\d+):)?(\d+)\.(\d+)$/);
 	if (!m) return null;
-	const minutes = parseInt(m[1] ?? '0', 10);
-	const seconds = parseInt(m[2], 10);
+	const minutes    = parseInt(m[1] ?? '0', 10);
+	const seconds    = parseInt(m[2], 10);
 	const fractional = m[3].padEnd(3, '0').slice(0, 3);
 	return minutes * 60_000 + seconds * 1_000 + parseInt(fractional, 10);
 }

--- a/packages/site/src/components/page/race/lapByLap/useLapByLapChartData.ts
+++ b/packages/site/src/components/page/race/lapByLap/useLapByLapChartData.ts
@@ -47,7 +47,7 @@ const lapsQuery = gql`
 
 type LapTimeRow = Pick<AppLapTime, 'lap' | 'position' | 'driverId' | 'timeText' | 'milliseconds'>;
 
-type RaceResultRow = Pick<RaceResult, 'positionDisplayOrder' | 'positionNumber'> & {
+type RaceResultRow = Pick<RaceResult, 'positionDisplayOrder' | 'positionNumber' | 'driverId'> & {
 	driver: Pick<Driver, 'id' | 'lastName'> | null;
 	team: { colors: { primaryHex: Maybe<string> } | null } | null;
 };
@@ -88,12 +88,17 @@ export const useLapByLapData = (season: number, round: number): LapByLapData => 
 
 		return {
 			loading,
+			// lap_times.driver_id holds the F1DB slug (e.g. "kimi-antonelli"),
+			// which matches race_results.driver_id but NOT the GraphQL Node id
+			// (`driver { id }` is Base64-encoded). Pre-F1DB the two happened to
+			// be equal; post-migration they diverged and the filter silently
+			// produced empty laps for every driver.
 			data:      results.map(r => ({
-				driverId: r.driver?.id,
+				driverId: r.driverId ?? undefined,
 				name:     r.driver?.lastName,
 				color:    r.team?.colors?.primaryHex || fallbackColor,
 				position: r.positionNumber ?? r.positionDisplayOrder,
-				laps:     lapTimes.filter(lt => lt.driverId === r.driver?.id)
+				laps:     lapTimes.filter(lt => lt.driverId === r.driverId)
 			})),
 			totalLaps: Math.max(...lapTimes.map(lt => lt.lap ?? 0))
 		};

--- a/scripts/run-ingest.ts
+++ b/scripts/run-ingest.ts
@@ -72,29 +72,42 @@ async function main(): Promise<void> {
 		console.log(`[ingest] release ${release.tag} already loaded — skipping dump apply`);
 	}
 
-	const lapClient = new Client({connectionString});
-	await lapClient.connect();
+	// Single long-lived pg Client across many Jolpica round-trips drops
+	// silently on Neon when the socket sits idle between fetches. Wrap
+	// every race in a connect/end pair (and fail-soft on errors) so a
+	// dead socket only kills the one iteration, not the whole run.
+	const lapClientOpts = {connectionString, keepAlive: true};
 	const lapReports: LapInsertReport[] = [];
+
+	const bootstrapClient = new Client(lapClientOpts);
+	await bootstrapClient.connect();
+	let races;
+	let resolve;
 	try {
-		const races   = await pickRacesNeedingLapTimes(lapClient, 2025, MAX_RACES);
-		const resolve = await buildDriverResolver(lapClient);
-		for (let i = 0; i < races.length; i++) {
-			const race = races[i];
-			try {
-				const report = await ingestLapTimesForRace(lapClient, resolve, race);
-				lapReports.push(report);
-				console.log(`[ingest] laps race ${race.raceId} (${race.year}/${race.round}): ${report.rowsInserted} inserted`);
-			} catch (err) {
-				const msg = err instanceof Error ? err.message : String(err);
-				if (msg.includes('Jolpica 429') || msg.includes('429')) {
-					console.log(`[ingest] Jolpica rate-limited at race ${i + 1}/${races.length}, stopping early`);
-					break;
-				}
-				console.error(`[ingest] lap fetch failed for race ${race.raceId}:`, err);
-			}
-		}
+		races   = await pickRacesNeedingLapTimes(bootstrapClient, 2025, MAX_RACES);
+		resolve = await buildDriverResolver(bootstrapClient);
 	} finally {
-		await lapClient.end();
+		await bootstrapClient.end();
+	}
+
+	for (let i = 0; i < races.length; i++) {
+		const race = races[i];
+		const lapClient = new Client(lapClientOpts);
+		try {
+			await lapClient.connect();
+			const report = await ingestLapTimesForRace(lapClient, resolve, race);
+			lapReports.push(report);
+			console.log(`[ingest] laps race ${race.raceId} (${race.year}/${race.round}): ${report.rowsInserted} inserted`);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (msg.includes('Jolpica 429') || msg.includes('429')) {
+				console.log(`[ingest] Jolpica rate-limited at race ${i + 1}/${races.length}, stopping early`);
+				break;
+			}
+			console.error(`[ingest] lap fetch failed for race ${race.raceId}:`, err);
+		} finally {
+			await lapClient.end().catch(() => {});
+		}
 	}
 
 	if (dumpApplied) {


### PR DESCRIPTION
## Summary

Hotfix-only PR carrying three production-bug fixes off `feature/mui-shadcn-migration` so prod can ship the lap-by-lap chart and a reliable ingest pipeline without waiting for the MUI migration to land.

### Commits

| Commit | Fix |
|---|---|
| `d2f5ed8` | **ingest:** per-race pg connect + `keepAlive: true` + fail-soft `.end().catch()`. Single long-lived pg `Client` across many Jolpica round-trips drops silently on Neon when the socket sits idle between fetches (last run died at race 1133 of a 500-race budget). |
| `76b376c` | **ingest:** self-pace Jolpica fetch under both anonymous tier limits (4/sec burst + 500/hour sustained). Sliding-window hour-cap throttle + `Retry-After`-respecting 429 safety net. GH Action `timeout-minutes` 15 → 60 so a saturated run that hits the hourly window can finish instead of leaving rows half-ingested. |
| `87d085a` | **lap-by-lap chart:** match `lap_times.driverId` (F1DB slug like `"kimi-antonelli"`) against `race_results.driverId` (same slug) instead of `race_results.driver.id` (Base64 GraphQL Node id). Pre-F1DB the two happened to be equal; post-migration they diverged and the filter silently produced empty laps for every driver. Verified: `2026/2` has 919 `lap_times` rows in prod and the chart was empty. |

## Verification

- `pnpm tsc --noEmit`: clean
- `pnpm lint`: 0 errors (7 pre-existing warnings)
- `pnpm test`: 22/22
- No GraphQL schema or query changes; codegen unchanged.

## Test plan

- [ ] Merge → wait for prod redeploy
- [ ] Hard-refresh `/2026/2` (and any other 2025+ race that has lap times loaded) — lap-by-lap chart renders driver lines
- [ ] Trigger `F1DB ingest` workflow against `main` (no `--ref` flag needed once merged): `gh workflow run "F1DB ingest"`
- [ ] Watch the run — should clear races until either the 500-race budget is exhausted or the 1-hour Jolpica window triggers a sleep
- [ ] Verify lap-time totalCount jumped: `curl -s https://effonehub.com/api/graphql -H 'Content-Type: application/json' -d '{"query":"{appLapTimes{totalCount}}"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
