### PR TITLE
Track B / M3: layout primitives sweep (Box/Stack/Grid/Container/Hidden/Divider → Tailwind)

### DIFF
--- a/packages/site/src/app/[season]/[round]/RoundContent.tsx
+++ b/packages/site/src/app/[season]/[round]/RoundContent.tsx
@@ -6,7 +6,7 @@ import {FastestLap, LapLeader, Pole, PositionsGained} from '@/components/page/ra
 import {OpenAILink, Page, Link, Tabs, type TabContent} from '@/components/ui';
 import {Race} from '@/gql/graphql';
 import useRace from '@/hooks/data/useRace';
-import {Box, Card, CardContent, CardHeader, CardMedia, Grid, Hidden, Typography} from '@mui/material';
+import {Card, CardContent, CardHeader, CardMedia, Typography} from '@mui/material';
 
 type Props = {
 	season: string;
@@ -61,7 +61,7 @@ export default function RoundContent({season: seasonStr, round: roundStr, race}:
 					<CardHeader title={<Link href={`/circuits/${race.circuit?.rowId}`}>{race.circuit?.fullName}</Link>}/>
 					<CardMedia><RaceMap points={points} onClick={onClick} height={140} centerOn={{latitude: race.circuit?.latitude, longitude: race.circuit?.longitude}} zoom/></CardMedia>
 					<CardContent>
-						<Typography variant="body1">{circuitDescription} <Box component="span" display="block"><OpenAILink/></Box></Typography>
+						<Typography variant="body1">{circuitDescription} <span className="block"><OpenAILink/></span></Typography>
 					</CardContent>
 				</Card>
 			)
@@ -79,18 +79,18 @@ export default function RoundContent({season: seasonStr, round: roundStr, race}:
 			extra={null}
 			action={
 				race.circuit && (
-					<Hidden mdDown>
+					<div className="hidden md:block">
 						<Card>
 							<CardMedia><RaceMap points={points} onClick={onClick} height={140} centerOn={{latitude: race.circuit.latitude, longitude: race.circuit.longitude}} zoom/></CardMedia>
 							<CardHeader title={<Link href={`/circuits/${race.circuit.rowId}`}>{race.circuit.fullName}</Link>}/>
 						</Card>
-					</Hidden>
+					</div>
 				)
 			}
 			actionProps={{xs: 0, md: 3}}
 		>
-			<Grid container spacing={2}>
-				<Grid item xs={12} md={8} lg={9} order={{xs: 2, md: 1}}>
+			<div className="grid grid-cols-12 gap-4">
+				<div className="col-span-12 md:col-span-8 lg:col-span-9 order-2 md:order-1">
 					<Card>
 						{
 							hasResults
@@ -102,30 +102,30 @@ export default function RoundContent({season: seasonStr, round: roundStr, race}:
 										{circuitDescription && (
 											<>
 												<Typography variant="body2">{circuitDescription}</Typography>
-												<Box textAlign="right" display="block"><OpenAILink/></Box>
+												<div className="block text-right"><OpenAILink/></div>
 											</>
 										)}
 									</CardContent>
 								)
 						}
 					</Card>
-				</Grid>
+				</div>
 
-				<Grid item xs={12} md={4} lg={3} order={{xs: 1, md: 2}}>
+				<div className="col-span-12 md:col-span-4 lg:col-span-3 order-1 md:order-2">
 					<Card sx={{height: '100%'}}>
 						<CardContent>
-							<Grid container spacing={2}>
+							<div className="grid grid-cols-12 gap-4">
 								<CardHeader title={`${seasonToShow} Season`}/>
 								<Pole season={seasonToShow} round={round} size="small"/>
 								<FastestLap season={seasonToShow} round={round} size="small"/>
-								<Hidden lgUp><Grid item xs={12}/></Hidden>
+								<div className="block lg:hidden col-span-12"/>
 								<LapLeader season={seasonToShow} round={round} size="small"/>
 								<PositionsGained season={seasonToShow} round={round} size="small"/>
-							</Grid>
+							</div>
 						</CardContent>
 					</Card>
-				</Grid>
-			</Grid>
+				</div>
+			</div>
 		</Page>
 	);
 }

--- a/packages/site/src/app/about/AboutContent.tsx
+++ b/packages/site/src/app/about/AboutContent.tsx
@@ -3,7 +3,7 @@
 import {Data, Dependencies, Mission, Repositories} from '@/components/page/about';
 import {Page} from '@/components/ui';
 import {Button as ShadcnButton} from '@/components/ui/shadcn/button';
-import {Button as MuiButton, Grid} from '@mui/material';
+import {Button as MuiButton} from '@mui/material';
 
 export default function AboutContent() {
 	return (
@@ -15,27 +15,27 @@ export default function AboutContent() {
 				<ShadcnButton>shadcn Button</ShadcnButton>
 				<MuiButton variant="contained">MUI Button</MuiButton>
 			</div>
-			<Grid container spacing={2}>
-				<Grid item xs={12} md={9}>
-					<Grid container spacing={2} alignItems="strech">
-						<Grid item xs={12}>
+			<div className="grid grid-cols-12 gap-4">
+				<div className="col-span-12 md:col-span-9">
+					<div className="grid grid-cols-12 gap-4 items-stretch">
+						<div className="col-span-12">
 							<Mission/>
-						</Grid>
+						</div>
 
-						<Grid item xs={12} md={6}>
+						<div className="col-span-12 md:col-span-6">
 							<Data/>
-						</Grid>
+						</div>
 
-						<Grid item xs={12} md={6}>
+						<div className="col-span-12 md:col-span-6">
 							<Repositories/>
-						</Grid>
-					</Grid>
-				</Grid>
+						</div>
+					</div>
+				</div>
 
-				<Grid item xs={12} md={3}>
+				<div className="col-span-12 md:col-span-3">
 					<Dependencies/>
-				</Grid>
-			</Grid>
+				</div>
+			</div>
 		</Page>
 	);
 }

--- a/packages/site/src/app/circuits/[circuitRef]/CircuitContent.tsx
+++ b/packages/site/src/app/circuits/[circuitRef]/CircuitContent.tsx
@@ -7,7 +7,7 @@ import {OpenAILink, Page} from '@/components/ui';
 import {useCircuitByRef} from '@/hooks/data';
 import {Tabs} from '@/components/ui';
 import useComponentDimensionsWithRef from '@/hooks/useComponentDimensionsWithRef';
-import {Card, CardContent, CardHeader, Divider, Grid, Hidden, Typography} from '@mui/material';
+import {Card, CardContent, CardHeader, Typography} from '@mui/material';
 import {Suspense} from 'react';
 
 export default function CircuitContent({circuitRef}: {circuitRef: string}) {
@@ -39,23 +39,23 @@ export default function CircuitContent({circuitRef}: {circuitRef: string}) {
 						{circuit.description?.description && (
 							<>
 								<Typography variant="body1">{circuit.description.description}</Typography>
-								<Divider orientation="horizontal" sx={{my: 1}}/>
+								<div className="border-t my-2"/>
 								<OpenAILink/>
 							</>
 						)}
 					</>
 				)}
 				action={(
-					<Hidden mdDown>
+					<div className="hidden md:block">
 						<Card sx={{height: '100%'}} ref={ref}>
 							<RaceMap points={points} onClick={onClick} height={height} centerOn={circuit} zoom/>
 						</Card>
-					</Hidden>
+					</div>
 				)}
 				actionProps={{xs: 0, md: 4, lg: 3}}
 			>
-				<Grid container spacing={2}>
-					<Grid item xs={12} md={8} lg={9} sx={{order: {xs: 2, md: 1}}}>
+				<div className="grid grid-cols-12 gap-4">
+					<div className="col-span-12 md:col-span-8 lg:col-span-9 order-2 md:order-1">
 						<Card>
 							<Tabs active="history" tabs={[
 								{
@@ -72,21 +72,21 @@ export default function CircuitContent({circuitRef}: {circuitRef: string}) {
 								}
 							]}/>
 						</Card>
-					</Grid>
+					</div>
 
-					<Grid item xs={12} md={4} lg={3} sx={{order: {xs: 1, md: 2}}}>
+					<div className="col-span-12 md:col-span-4 lg:col-span-3 order-1 md:order-2">
 						<Card sx={{height: '100%'}}>
 							<CardHeader title={`${seasonToShow} Season`}/>
 							<CardContent>
-								<Grid container spacing={2}>
+								<div className="grid grid-cols-12 gap-4">
 									<LapLeader data={seasonToShow === currentSeason ? data : lastSeasonData} loading={false}/>
 									<MostWins data={seasonToShow === currentSeason ? data : lastSeasonData} loading={false}/>
 									<FastestLap data={seasonToShow === currentSeason ? data : lastSeasonData} loading={false}/>
-								</Grid>
+								</div>
 							</CardContent>
 						</Card>
-					</Grid>
-				</Grid>
+					</div>
+				</div>
 			</Page>
 		</Suspense>
 	);

--- a/packages/site/src/app/constructors/[teamRef]/ConstructorContent.tsx
+++ b/packages/site/src/app/constructors/[teamRef]/ConstructorContent.tsx
@@ -7,7 +7,7 @@ import {Flag, Page, Tabs} from '@/components/ui';
 import {useGetTeamColor} from '@/hooks';
 import {useConstructorData} from '@/hooks/data';
 import useTeam from '@/hooks/data/useTeam';
-import {Box, Card, CardContent, CardHeader, CardMedia, Divider, Grid, Skeleton, Typography, useTheme} from '@mui/material';
+import {Card, CardContent, CardHeader, CardMedia, Skeleton, Typography, useTheme} from '@mui/material';
 
 /**
  * The subset of `Team` fields ConstructorContent reads at the top level.
@@ -23,22 +23,22 @@ export type TeamProp = {
 };
 
 const TeamDetails = ({team}: {team: TeamProp}) => (
-	<Grid container spacing={4} sx={{fontSize: '1.5em', fontWeight: 'bold'}} alignItems="center">
-		<Grid item><Typography variant="h2">{team.name}</Typography></Grid>
-		{team.countryId && <Grid item><Flag nationality={team.countryId} size={48}/></Grid>}
-	</Grid>
+	<div className="flex flex-row flex-wrap gap-8 items-center text-[1.5em] font-bold">
+		<div><Typography variant="h2">{team.name}</Typography></div>
+		{team.countryId && <div><Flag nationality={team.countryId} size={48}/></div>}
+	</div>
 );
 
 const PageSkeleton = () => (
 	<Page title="Loading">
-		<Grid container spacing={2}>
-			<Grid item xs={12} md={8} lg={9} order={{xs: 2, md: 1}}>
+		<div className="grid grid-cols-12 gap-4">
+			<div className="col-span-12 md:col-span-8 lg:col-span-9 order-2 md:order-1">
 				<Card variant="outlined">
 					<Skeleton variant="rectangular" height={600}/>
 				</Card>
-			</Grid>
+			</div>
 
-			<Grid item xs={12} md={4} lg={3} order={{xs: 1, md: 2}}>
+			<div className="col-span-12 md:col-span-4 lg:col-span-3 order-1 md:order-2">
 				<Card variant="outlined">
 					<CardMedia>
 						<Skeleton variant="rectangular" sx={{height: {xs: 24, md: 48}}}/>
@@ -50,12 +50,12 @@ const PageSkeleton = () => (
 							<Skeleton variant="text"/>
 							<Skeleton variant="text"/>
 						</Typography>
-						<Divider orientation="horizontal" sx={{my: 1}}/>
+						<div className="border-t my-2"/>
 						<Skeleton variant="text"/>
 					</CardContent>
 				</Card>
-			</Grid>
-		</Grid>
+			</div>
+		</div>
 	</Page>
 );
 
@@ -100,7 +100,7 @@ export default function ConstructorContent({teamRef, team}: Props) {
 	return (
 		<Page
 			title={<TeamDetails team={team}/>}
-			subheader={<><Divider orientation="horizontal" sx={{my: 1}}/></>}
+			subheader={<><div className="border-t my-2"/></>}
 			headerProps={{
 				sx: {
 					position:   'relative',
@@ -118,44 +118,44 @@ export default function ConstructorContent({teamRef, team}: Props) {
 				}
 			}}
 		>
-			<Grid container spacing={2}>
-				<Grid item xs={12} md={isInCurrentSeason ? 8 : 12} lg={isInCurrentSeason ? 9 : 12} order={{xs: 2, md: 1}}>
+			<div className="grid grid-cols-12 gap-4">
+				<div className={`col-span-12 ${isInCurrentSeason ? 'md:col-span-8 lg:col-span-9' : 'md:col-span-12 lg:col-span-12'} order-2 md:order-1`}>
 					{bio?.extract && (
 						<Card variant="outlined" sx={{mb: 2, p: 2}}>
 							{bio.thumbnailUrl && (
-								<Box component="img" src={bio.thumbnailUrl} alt={team.name ?? ''} sx={{float: 'right', ml: 2, mb: 1, width: 120, height: 120, objectFit: 'cover', borderRadius: 1}}/>
+								<img src={bio.thumbnailUrl} alt={team.name ?? ''} className="float-right ml-4 mb-2 w-[120px] h-[120px] object-cover rounded-sm"/>
 							)}
 							<Typography variant="body1">{bio.extract}</Typography>
-							<Box sx={{clear: 'both'}}/>
+							<div className="clear-both"/>
 						</Card>
 					)}
 					<Card variant="outlined">
 						<Tabs active="history" tabs={tabs}/>
 					</Card>
-				</Grid>
+				</div>
 
 				{
 					isInCurrentSeason && (
-						<Grid item xs={12} md={4} lg={3} order={{xs: 1, md: 2}}>
+						<div className="col-span-12 md:col-span-4 lg:col-span-3 order-1 md:order-2">
 							<Card variant="outlined">
 								<CardHeader title={`${currentSeason} Season Stats`}/>
 								<CardContent>
-									<Grid container spacing={2}>
+									<div className="grid grid-cols-12 gap-4">
 										<DriverPoints constructorId={team.rowId} season={currentSeason} place={1}/>
 										<DriverPoints constructorId={team.rowId} season={currentSeason} place={2}/>
-										<Grid item xs={12}><Typography variant="h4">Podiums</Typography></Grid>
+										<div className="col-span-12"><Typography variant="h4">Podiums</Typography></div>
 										<DriverPodiums constructorId={team.rowId} season={currentSeason} place={1}/>
 										<DriverPodiums constructorId={team.rowId} season={currentSeason} place={2}/>
-										<Grid item xs={12}><Typography variant="h4">Qualifying Head-to-Head</Typography></Grid>
+										<div className="col-span-12"><Typography variant="h4">Qualifying Head-to-Head</Typography></div>
 										<DriverQualifying constructorId={team.rowId} season={currentSeason} place={1}/>
 										<DriverQualifying constructorId={team.rowId} season={currentSeason} place={2}/>
-									</Grid>
+									</div>
 								</CardContent>
 							</Card>
-						</Grid>
+						</div>
 					)
 				}
-			</Grid>
+			</div>
 		</Page>
 	);
 }

--- a/packages/site/src/app/drivers/[driverRef]/DriverContent.tsx
+++ b/packages/site/src/app/drivers/[driverRef]/DriverContent.tsx
@@ -4,7 +4,7 @@ import {DriverAvatar, useAppState} from '@/components/app';
 import {Career, Circuits, Season} from '@/components/page/driver';
 import {Flag, Page, Tabs} from '@/components/ui';
 import {useGetTeamColor} from '@/hooks';
-import {Box, Card, Divider, Grid, Hidden, Typography, useTheme} from '@mui/material';
+import {Card, Typography, useTheme} from '@mui/material';
 
 /**
  * The subset of `Driver` fields DriverContent reads at the top level.
@@ -37,15 +37,15 @@ export type DriverPageProp = {
 };
 
 const DriverDetails = ({driver}: {driver: DriverPageProp}) => (
-	<Grid container spacing={2} sx={{fontSize: '1.5em', fontWeight: 'bold'}} alignItems="center">
-		<Grid item><Typography variant="h2">{driver.firstName} {driver.lastName}</Typography></Grid>
-		<Hidden mdDown>
-			{driver.nationalityCountryId && <Grid item><Flag nationality={driver.nationalityCountryId} size={48}/></Grid>}
-			<Grid item xs/>
-			<Grid item><Typography variant="h2" sx={{fontWeight: 'bold'}}>{driver.abbreviation}</Typography></Grid>
-			<Grid item sx={{fontFamily: 'Racing Sans One', fontSize: '1.1em'}}>{driver.permanentNumber}</Grid>
-		</Hidden>
-	</Grid>
+	<div className="flex flex-row flex-wrap gap-4 items-center text-[1.5em] font-bold">
+		<div><Typography variant="h2">{driver.firstName} {driver.lastName}</Typography></div>
+		<div className="hidden md:contents">
+			{driver.nationalityCountryId && <div><Flag nationality={driver.nationalityCountryId} size={48}/></div>}
+			<div className="flex-1"/>
+			<div><Typography variant="h2" sx={{fontWeight: 'bold'}}>{driver.abbreviation}</Typography></div>
+			<div style={{fontFamily: 'Racing Sans One', fontSize: '1.1em'}}>{driver.permanentNumber}</div>
+		</div>
+	</div>
 );
 
 export default function DriverContent({driver}: {driver: DriverPageProp | null}) {
@@ -77,11 +77,11 @@ export default function DriverContent({driver}: {driver: DriverPageProp | null})
 			title={<DriverDetails driver={driver}/>}
 			action={
 				bio?.thumbnailUrl
-					? <Box component="img" src={bio.thumbnailUrl} alt={`${driver.firstName} ${driver.lastName}`} sx={{width: 200, height: 200, objectFit: 'cover', borderRadius: 1}}/>
+					? <img src={bio.thumbnailUrl} alt={`${driver.firstName} ${driver.lastName}`} className="w-[200px] h-[200px] object-cover rounded-sm"/>
 					: <DriverAvatar driverId={driver.rowId} size={200}/>
 			}
 			actionProps={{xs: 'auto'}}
-			subheader={<><Divider orientation="horizontal" sx={{my: 1}}/></>}
+			subheader={<><div className="border-t my-2"/></>}
 			headerProps={{
 				sx: {
 					position:   'relative',

--- a/packages/site/src/components/app/ErrorBoundary.tsx
+++ b/packages/site/src/components/app/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import {Alert, AlertTitle} from '@/components/ui/shadcn/alert';
 import {faFlag} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {Card, Container} from '@mui/material';
+import {Card} from '@mui/material';
 import {Component, ComponentProps, ErrorInfo} from 'react';
 
 type ErrorBoundaryState = {
@@ -11,14 +11,14 @@ type ErrorBoundaryState = {
 
 export function ErrorCard({message}: { message?: string }) {
 	return (
-		<Container maxWidth="md">
+		<div className="mx-auto max-w-3xl px-4">
 			<Card>
 				<Alert variant="destructive" className="py-4 px-8">
 					<FontAwesomeIcon icon={faFlag} size="2x"/>
 					<AlertTitle className="text-2xl">{message}</AlertTitle>
 				</Alert>
 			</Card>
-		</Container>
+		</div>
 	);
 }
 

--- a/packages/site/src/components/app/bylines/DriverByLine.tsx
+++ b/packages/site/src/components/app/bylines/DriverByLine.tsx
@@ -2,7 +2,7 @@ import {Flag, FlagProps, Link} from '@/components/ui';
 import {useDriver} from '@/hooks/data';
 import {DriverId} from '@/types';
 import {Driver} from '@/gql/graphql';
-import {Grid, Hidden, Skeleton, Typography} from '@mui/material';
+import {Skeleton, Typography} from '@mui/material';
 import {memo} from 'react';
 import {DriverAvatar, DriverAvatarProps} from '../avatars';
 
@@ -31,13 +31,13 @@ const DriverSkeleton = ({variant = 'full', avatarProps = {}}: BaseByLineProps) =
 		
 		case 'full':
 			return (
-				<Grid container spacing={1} alignItems="center" sx={{flexWrap: 'nowrap'}}>
-					<Hidden smDown><Grid item><DriverAvatar driverId={undefined} {...avatarProps}/></Grid></Hidden>
-					<Grid item><Typography><Skeleton/></Typography></Grid>
-				</Grid>
+				<div className="flex flex-row flex-nowrap gap-2 items-center">
+					<div className="hidden sm:block"><DriverAvatar driverId={undefined} {...avatarProps}/></div>
+					<div><Typography><Skeleton/></Typography></div>
+				</div>
 			);
 	}
-	
+
 	return null;
 };
 
@@ -69,11 +69,11 @@ const ByDriver = (props: ByLinePropsByDriver) => {
 
 		case 'full':
 			return (
-				<Grid container spacing={1} alignItems="center" sx={{flexWrap: 'nowrap'}}>
-					<Hidden smDown><Grid item><DriverAvatar driverId={rowId} {...avatarProps}/></Grid></Hidden>
-					<Grid item><Typography><Link href={`/drivers/${rowId}`}>{name}</Link></Typography></Grid>
-					{!noFlag && nationalityCountryId && <Hidden mdDown><Grid item><Typography><Flag nationality={nationalityCountryId} {...flagProps}/></Typography></Grid></Hidden>}
-				</Grid>
+				<div className="flex flex-row flex-nowrap gap-2 items-center">
+					<div className="hidden sm:block"><DriverAvatar driverId={rowId} {...avatarProps}/></div>
+					<div><Typography><Link href={`/drivers/${rowId}`}>{name}</Link></Typography></div>
+					{!noFlag && nationalityCountryId && <div className="hidden md:block"><Typography><Flag nationality={nationalityCountryId} {...flagProps}/></Typography></div>}
+				</div>
 			);
 	}
 	

--- a/packages/site/src/components/app/charts/ChartSwitcherCharts.tsx
+++ b/packages/site/src/components/app/charts/ChartSwitcherCharts.tsx
@@ -1,4 +1,3 @@
-import {Box} from '@mui/material';
 import {ActiveChart, ChartSwitcherChart} from './types';
 
 type ChartSwitcherProps = {
@@ -9,7 +8,7 @@ type ChartSwitcherProps = {
 export default function ChartSwitcherCharts({active, charts}: ChartSwitcherProps) {
 	return (
 		<>
-			{charts.map(({id, chart}) => <Box key={id} height="100%" width="100%" sx={{display: id === active ? 'block' : 'none'}}>{chart}</Box>)}
+			{charts.map(({id, chart}) => <div key={id} className="h-full w-full" style={{display: id === active ? 'block' : 'none'}}>{chart}</div>)}
 		</>
 	);
 }

--- a/packages/site/src/components/app/header/Header.tsx
+++ b/packages/site/src/components/app/header/Header.tsx
@@ -1,5 +1,5 @@
 import {Link} from '@/components/ui';
-import {AppBar, darken, Grid, lighten, Toolbar, Typography, useTheme} from '@mui/material';
+import {AppBar, darken, lighten, Toolbar, Typography, useTheme} from '@mui/material';
 import {blueGrey} from '@mui/material/colors';
 import NavMenu from './NavMenu';
 
@@ -29,17 +29,17 @@ export default function Header() {
 					}
 				}}>
 				<Toolbar>
-					<Grid container spacing={1} alignItems="center">
-						<Grid item>
+					<div className="flex flex-row flex-wrap gap-2 items-center w-full">
+						<div>
 							<Link href="/" color="inherit" className="no-underline hover:no-underline [&_*]:font-[Anton] [&_*]:text-[48px]">
 								<Typography component="h1">
 									EFF<Typography component="span" sx={{opacity: 1, px: .5, color: lightRed}}>ONE</Typography>HUB
 								</Typography>
 							</Link>
-						</Grid>
-						<Grid item xs/>
+						</div>
+						<div className="flex-1"/>
 						<NavMenu/>
-					</Grid>
+					</div>
 				</Toolbar>
 			</AppBar>
 			<Toolbar sx={{my: 2}}/>

--- a/packages/site/src/components/app/header/NavMenu.tsx
+++ b/packages/site/src/components/app/header/NavMenu.tsx
@@ -2,7 +2,7 @@ import {Link} from '@/components/ui';
 import {useAppState} from '@/components/app';
 import {faBars} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {Grid, Hidden, IconButton, Menu, MenuItem, useTheme} from '@mui/material';
+import {IconButton, Menu, MenuItem, useTheme} from '@mui/material';
 import {usePathname, useRouter} from 'next/navigation';
 import {MouseEvent, useState} from 'react';
 
@@ -86,46 +86,44 @@ export default function NavMenu() {
 	};
 	
 	return <>
-		<Hidden mdDown>
+		<div className="hidden md:contents">
 			{navLinks.map(({path, label, active}, i) => {
 					return (
-						<Grid item key={i}>
+						<div key={i}>
 							<Link color="inherit" className={`${navLinkClass} ${active ? 'bg-secondary text-secondary-foreground' : ''}`} href={path}>{label}</Link>
-						</Grid>
+						</div>
 					);
 				}
 			)}
-		</Hidden>
-		<Hidden mdUp>
-			<Grid item>
-				<div>
-					<IconButton
-						id="hamburger-button"
-						aria-label="toggle navigation menu"
-						aria-controls={open ? 'hamburger-menu' : undefined}
-						aria-haspopup="true"
-						aria-expanded={open ? 'true' : undefined}
-						onClick={handleClick}
-					>
-						<FontAwesomeIcon icon={faBars} color={theme.palette.common.white}/>
-					</IconButton>
-					<Menu
-						hideBackdrop
-						id="hamburger-menu"
-						anchorEl={anchorEl}
-						open={open}
-						onClose={handleClose}
-						MenuListProps={{
-							'aria-labelledby': 'hamburger-button'
-						}}
-					>
-						{navLinks.map(({path, label, active}) => {
-								return <MenuItem selected={active} key={String(path)} onClick={handleLink(String(path))}>{label}</MenuItem>;
-							}
-						)}
-					</Menu>
-				</div>
-			</Grid>
-		</Hidden>
+		</div>
+		<div className="md:hidden">
+			<div>
+				<IconButton
+					id="hamburger-button"
+					aria-label="toggle navigation menu"
+					aria-controls={open ? 'hamburger-menu' : undefined}
+					aria-haspopup="true"
+					aria-expanded={open ? 'true' : undefined}
+					onClick={handleClick}
+				>
+					<FontAwesomeIcon icon={faBars} color={theme.palette.common.white}/>
+				</IconButton>
+				<Menu
+					hideBackdrop
+					id="hamburger-menu"
+					anchorEl={anchorEl}
+					open={open}
+					onClose={handleClose}
+					MenuListProps={{
+						'aria-labelledby': 'hamburger-button'
+					}}
+				>
+					{navLinks.map(({path, label, active}) => {
+							return <MenuItem selected={active} key={String(path)} onClick={handleLink(String(path))}>{label}</MenuItem>;
+						}
+					)}
+				</Menu>
+			</div>
+		</div>
 	</>;
 }

--- a/packages/site/src/components/app/header/NavMenu.tsx
+++ b/packages/site/src/components/app/header/NavMenu.tsx
@@ -2,7 +2,7 @@ import {Link} from '@/components/ui';
 import {useAppState} from '@/components/app';
 import {faBars} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {IconButton, Menu, MenuItem, useTheme} from '@mui/material';
+import {IconButton, Menu, MenuItem, useMediaQuery, useTheme} from '@mui/material';
 import {usePathname, useRouter} from 'next/navigation';
 import {MouseEvent, useState} from 'react';
 
@@ -55,6 +55,7 @@ export const useNavLinks = (pathname: string) => {
 export default function NavMenu() {
 	const router                  = useRouter();
 	const theme                   = useTheme();
+	const isMobile                = useMediaQuery(theme.breakpoints.down('md'));
 	const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 	const open                    = Boolean(anchorEl);
 	const pathname                = usePathname() || '';
@@ -85,18 +86,8 @@ export default function NavMenu() {
 		handleClose();
 	};
 	
-	return <>
-		<div className="hidden md:contents">
-			{navLinks.map(({path, label, active}, i) => {
-					return (
-						<div key={i}>
-							<Link color="inherit" className={`${navLinkClass} ${active ? 'bg-secondary text-secondary-foreground' : ''}`} href={path}>{label}</Link>
-						</div>
-					);
-				}
-			)}
-		</div>
-		<div className="md:hidden">
+	if (isMobile) {
+		return (
 			<div>
 				<IconButton
 					id="hamburger-button"
@@ -124,6 +115,17 @@ export default function NavMenu() {
 					)}
 				</Menu>
 			</div>
-		</div>
+		);
+	}
+
+	return <>
+		{navLinks.map(({path, label, active}, i) => {
+				return (
+					<div key={i}>
+						<Link color="inherit" className={`${navLinkClass} ${active ? 'bg-secondary text-secondary-foreground' : ''}`} href={path}>{label}</Link>
+					</div>
+				);
+			}
+		)}
 	</>;
 }

--- a/packages/site/src/components/app/maps/MapTooltip.tsx
+++ b/packages/site/src/components/app/maps/MapTooltip.tsx
@@ -1,4 +1,4 @@
-import {Box, Typography} from '@mui/material';
+import {Typography} from '@mui/material';
 
 type MapTooltipProps = {
 	feature: any;
@@ -8,10 +8,10 @@ export default function MapTooltip({feature}: MapTooltipProps) {
 	if (feature?.geometry?.type !== 'Point') {
 		return null;
 	}
-	
+
 	return (
-		<Box py={1} px={2}>
+		<div className="py-2 px-4">
 			<Typography>{feature.properties.name}</Typography>
-		</Box>
+		</div>
 	);
 }

--- a/packages/site/src/components/app/maps/RaceMap.tsx
+++ b/packages/site/src/components/app/maps/RaceMap.tsx
@@ -1,7 +1,7 @@
 import {NivoTooltipFactory, RequiredByPropTypes, useNivoTheme} from '@/components/ui/nivo';
 import {Circuit} from '@/gql/graphql';
 import useComponentDimensionsWithRef from '@/hooks/useComponentDimensionsWithRef';
-import {alpha, Box, useTheme} from '@mui/material';
+import {alpha, useTheme} from '@mui/material';
 import {GeoMapEventHandler, ResponsiveGeoMap} from '@nivo/geo';
 import {useEffect, useState} from 'react';
 import MapTooltip from './MapTooltip';
@@ -76,8 +76,8 @@ export default function RaceMap(props: RaceMapProps) {
 	
 	// PropTypes vs TS mismatches
 	return (
-		<Box ref={ref} sx={{position: 'relative'}} aria-hidden>
-			<Box sx={{height, width}}>
+		<div ref={ref} className="relative" aria-hidden>
+			<div style={{height, width}}>
 				<ResponsiveGeoMap
 					{...RequiredByPropTypes.GeoMap}
 					
@@ -113,7 +113,7 @@ export default function RaceMap(props: RaceMapProps) {
 					tooltip={NivoTooltipFactory(MapTooltip)}
 					onClick={onClick}
 				/>
-			</Box>
-		</Box>
+			</div>
+		</div>
 	);
 }

--- a/packages/site/src/components/app/stats/Stats.tsx
+++ b/packages/site/src/components/app/stats/Stats.tsx
@@ -1,10 +1,9 @@
-import {Grid} from '@mui/material';
 import {PropsWithChildren} from 'react';
 
 export default function Stats({children}: PropsWithChildren) {
 	return (
-		<Grid container spacing={2} sx={{py: 0}} justifyContent="stretch" flexWrap={{xs: 'wrap', lg: 'nowrap'}}>
+		<div className="flex flex-row flex-wrap lg:flex-nowrap gap-4 justify-stretch py-0">
 			{children}
-		</Grid>
+		</div>
 	);
 };

--- a/packages/site/src/components/page/constructor/season/SeasonChart.tsx
+++ b/packages/site/src/components/page/constructor/season/SeasonChart.tsx
@@ -1,7 +1,7 @@
 import {RequiredByPropTypes, useNivoTheme} from '@/components/ui/nivo';
 import {useGetTeamColor} from '@/hooks';
 import type {SimpleApolloResult} from '@/app/lib/apollo-types';
-import {alpha, Box, Skeleton} from '@mui/material';
+import {alpha, Skeleton} from '@mui/material';
 import {ResponsiveLine, Serie as LineSerie} from '@nivo/line';
 import {ConstructorPageData} from '../types';
 
@@ -47,7 +47,7 @@ export default function SeasonChart({data, loading}: SeasonChartProps) {
 	);
 	
 	return (
-		<Box sx={{height: 132, width: '100%'}} aria-hidden>
+		<div className="w-full h-[132px]" aria-hidden>
 			<ResponsiveLine
 				{...RequiredByPropTypes.Line}
 				theme={nivoTheme}
@@ -89,6 +89,6 @@ export default function SeasonChart({data, loading}: SeasonChartProps) {
 					}
 				]}
 			/>
-		</Box>
+		</div>
 	);
 }

--- a/packages/site/src/components/page/driver/career/CareerPerformanceBurst.tsx
+++ b/packages/site/src/components/page/driver/career/CareerPerformanceBurst.tsx
@@ -1,6 +1,6 @@
 import {NivoTooltipFactory, useNivoTheme} from '@/components/ui/nivo';
 import {useResultsColors} from '@/hooks';
-import {Box, Card, Skeleton, Typography, useTheme} from '@mui/material';
+import {Card, Skeleton, Typography, useTheme} from '@mui/material';
 import {ComputedDatum, ResponsiveSunburst} from '@nivo/sunburst';
 import usePerformanceData from '../usePerformanceData';
 import useCareerData from './useCareerData';
@@ -9,9 +9,9 @@ const CareerPerformanceTooltip = (datum: ComputedDatum<BurstDatum>) => {
 	const {label} = datum.data;
 	
 	return (
-		<Box py={1} px={2}>
+		<div className="py-2 px-4">
 			<Typography>{label}</Typography>
-		</Box>
+		</div>
 	);
 };
 

--- a/packages/site/src/components/page/driver/circuits/dialog/CircuitDialog.tsx
+++ b/packages/site/src/components/page/driver/circuits/dialog/CircuitDialog.tsx
@@ -3,7 +3,7 @@ import {DriverId} from '@/types';
 import {faTimes} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {Dialog, Tabs} from '@/components/ui';
-import {Card, Grid, Typography} from '@mui/material';
+import {Card, Typography} from '@mui/material';
 import CircuitChart from './CircuitChart';
 import CircuitPerformance from './CircuitPerformance';
 import CircuitTable from './CircuitTable';
@@ -36,8 +36,8 @@ export default function CircuitDialog({driverId, circuitId, onClose}: CircuitPro
 					<Typography paragraph variant="subtitle1"><DriverByLine id={driverId} variant="name"/></Typography>
 				</>
 			}>
-			<Grid container spacing={2}>
-				<Grid item xs={9}>
+			<div className="grid grid-cols-12 gap-4">
+				<div className="col-span-9">
 					<Tabs active="results" tabs={[
 						{
 							id:      'results',
@@ -55,18 +55,18 @@ export default function CircuitDialog({driverId, circuitId, onClose}: CircuitPro
 							content: <LapTimesByYearBox data={data} loading={loading}/>
 						}
 					]}/>
-				</Grid>
-				<Grid item xs={3}>
-					<Grid container spacing={1}>
-						<Grid item xs={12}>
+				</div>
+				<div className="col-span-3">
+					<div className="grid grid-cols-12 gap-2">
+						<div className="col-span-12">
 							<Card sx={{mb: 2}}>
 								<RaceMap points={points} onClick={onClick} height={200} centerOn={{latitude: circuit.latitude, longitude: circuit.longitude}} zoom/>
 							</Card>
-						</Grid>
-						<Grid item xs={12}><CircuitPerformance data={data} loading={loading}/></Grid>
-					</Grid>
-				</Grid>
-			</Grid>
+						</div>
+						<div className="col-span-12"><CircuitPerformance data={data} loading={loading}/></div>
+					</div>
+				</div>
+			</div>
 		</Dialog>
 	);
 }

--- a/packages/site/src/components/page/driver/circuits/dialog/LapTimesByYearSwarm.tsx
+++ b/packages/site/src/components/page/driver/circuits/dialog/LapTimesByYearSwarm.tsx
@@ -1,7 +1,7 @@
 import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
 import {useNivoTheme} from '@/components/ui/nivo';
 import type {SimpleApolloResult} from '@/app/lib/apollo-types';
-import {Box, Skeleton} from '@mui/material';
+import {Skeleton} from '@mui/material';
 import {ResponsiveSwarmPlot} from '@nivo/swarmplot';
 import {SwarmData, useMapLapTimeDataToSwarmChart} from './mapLapTimeDataToSwarmChart';
 import {CircuitDialogData} from './types';
@@ -31,7 +31,7 @@ export default function LapTimesByYearSwarm({data, loading}: LapTimesChartProps)
 	const max   = Math.max(...chartData.map(d => d.milliseconds));
 	
 	return (
-		<Box sx={{height: '60vh', width: '100%'}} aria-hidden>
+		<div className="w-full h-[60vh]" aria-hidden>
 			<ResponsiveSwarmPlot
 				theme={nivoTheme}
 				data={chartData}
@@ -73,6 +73,6 @@ export default function LapTimesByYearSwarm({data, loading}: LapTimesChartProps)
 					tickValues:   0
 				}}
 			/>
-		</Box>
+		</div>
 	);
 }

--- a/packages/site/src/components/page/race/Place.tsx
+++ b/packages/site/src/components/page/race/Place.tsx
@@ -4,7 +4,7 @@ import {useDriver} from '@/hooks/data';
 import {DriverId} from '@/types';
 import {faAsterisk} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {Card, CardHeader, Divider, SxProps, Typography} from '@mui/material';
+import {Card, CardHeader, SxProps, Typography} from '@mui/material';
 
 type PlaceProps = {
 	driverId?: DriverId;
@@ -32,8 +32,8 @@ export default function Place({driverId, place, points, wins, asterisk = false, 
 				title={<Typography noWrap><Link href={`/drivers/${rowId}`}>{name}</Link> {asterisk && <FontAwesomeIcon icon={faAsterisk} title="We all know what really happened"/>}</Typography>}
 				subheader={<>
 					{place ? `P${place} ` : ''}
-					{points ? <Typography variant="caption"><Divider orientation="vertical"/> {points} pts</Typography> : ''}
-					{typeof wins === 'number' ? <Typography variant="caption"><Divider orientation="vertical"/> {wins} wins</Typography> : ''}
+					{points ? <Typography variant="caption"><span className="inline-block border-l mx-2 h-3 align-middle"/> {points} pts</Typography> : ''}
+					{typeof wins === 'number' ? <Typography variant="caption"><span className="inline-block border-l mx-2 h-3 align-middle"/> {wins} wins</Typography> : ''}
 				</>}
 			/>
 		</Card>

--- a/packages/site/src/components/page/race/Podium.tsx
+++ b/packages/site/src/components/page/race/Podium.tsx
@@ -1,5 +1,4 @@
 import {RaceResult} from '@/gql/graphql';
-import {Grid} from '@mui/material';
 import Place from './Place';
 
 export default function Podium({results}: {
@@ -8,16 +7,16 @@ export default function Podium({results}: {
 	if (!results?.length) {
 		return null;
 	}
-	
+
 	const [p1, p2, p3] = results;
-	
+
 	return (
 		<>
 			{
 				[p1, p2, p3].map((p, i) => p.driver && (
-						<Grid item key={p.driver.rowId}>
+						<div key={p.driver.rowId}>
 							<Place driverId={p.driver.rowId} place={i + 1} sx={{height: '100%'}}/>
-						</Grid>
+						</div>
 					)
 				)
 			}

--- a/packages/site/src/components/page/race/lapByLap/LapByLap.tsx
+++ b/packages/site/src/components/page/race/lapByLap/LapByLap.tsx
@@ -1,7 +1,7 @@
 import {NivoTooltipFactory, useNivoTheme} from '@/components/ui/nivo';
 import {DriverId} from '@/types';
 import {Maybe} from '@/gql/graphql';
-import {Box, Skeleton} from '@mui/material';
+import {Skeleton} from '@mui/material';
 import {ResponsiveBump} from '@nivo/bump';
 import LapByLapTooltip from './LapByLapTooltip';
 import useLapByLapChartData, {useLapByLapData} from './useLapByLapChartData';
@@ -85,9 +85,9 @@ function LapByLap({season, round}: LapByLapProps) {
 	}
 	
 	return (
-		<Box sx={{height, width: '100%'}} aria-hidden>
+		<div className="w-full" style={{height}} aria-hidden>
 			{content}
-		</Box>
+		</div>
 	);
 }
 

--- a/packages/site/src/components/page/race/pitStops/PitStopsChart.tsx
+++ b/packages/site/src/components/page/race/pitStops/PitStopsChart.tsx
@@ -1,6 +1,6 @@
 import {NivoTooltipFactory, useNivoTheme} from '@/components/ui/nivo';
 import {useGetAccessibleColor} from '@/hooks';
-import {Box, Skeleton, useMediaQuery, useTheme} from '@mui/material';
+import {Skeleton, useMediaQuery, useTheme} from '@mui/material';
 import {BarSvgProps, ResponsiveBar} from '@nivo/bar';
 import {PitStopTableRow} from './PitStops';
 import PitStopTooltip from './PitStopTooltip';
@@ -69,7 +69,7 @@ export default function PitStopsChart({maxStops, pitStops}: PitStopsChartProps) 
 	}
 	
 	return (
-		<Box sx={{height: isSmall ? 400 : 150, mb: 2}} aria-hidden>
+		<div className="mb-4" style={{height: isSmall ? 400 : 150}} aria-hidden>
 			<ResponsiveBar
 				theme={nivoTheme}
 				indexBy="code"
@@ -84,6 +84,6 @@ export default function PitStopsChart({maxStops, pitStops}: PitStopsChartProps) 
 				{...layoutProps}
 				margin={{top: 16, right: 16, bottom: 32, left: 16, ...layoutProps.margin}}
 			/>
-		</Box>
+		</div>
 	);
 }

--- a/packages/site/src/components/page/raceWeekend/RaceWeekend.tsx
+++ b/packages/site/src/components/page/raceWeekend/RaceWeekend.tsx
@@ -1,6 +1,6 @@
 import {useEffTheme} from '@/components/ui';
 import {getDateWithTime} from '@/helpers';
-import {alpha, Card, CardActions, CardContent, CardHeader, Grid, ThemeProvider, Typography} from '@mui/material';
+import {alpha, Card, CardActions, CardContent, CardHeader, ThemeProvider, Typography} from '@mui/material';
 import NextRaceCountdown from './NextRaceCountdown';
 import NextRaceSchedule from './NextRaceSchedule';
 import useNextRaceData from './useNextRaceData';
@@ -40,7 +40,7 @@ export default function RaceWeekend({season}: RaceWeekendProps) {
 		const raceDate = new Date(`${race.date}T${race.time}`);
 		
 		return (
-			<Grid item xs={12} md={12}>
+			<div className="col-span-12">
 				<ThemeProvider theme={darkTheme}>
 					<Card sx={sx} id="next-race-weekend">
 						<CardHeader
@@ -58,7 +58,7 @@ export default function RaceWeekend({season}: RaceWeekendProps) {
 						</CardActions>
 					</Card>
 				</ThemeProvider>
-			</Grid>
+			</div>
 		);
 	}
 };

--- a/packages/site/src/components/page/season/Season.tsx
+++ b/packages/site/src/components/page/season/Season.tsx
@@ -5,7 +5,7 @@ import {DriverStandings, TeamStandings} from '@/components/page/season/standings
 import {DNFs, FastestLap, FastestLaps, LapLeader, Poles, PositionsGained, SprintWins, Wins} from '@/components/page/season/stats';
 import {Page} from '@/components/ui';
 import {Season as SeasonT} from '@/gql/graphql';
-import {Card, CardContent, CardHeader, Grid, Hidden} from '@mui/material';
+import {Card, CardContent, CardHeader} from '@mui/material';
 import {Suspense} from 'react';
 
 type SeasonProps = {
@@ -19,49 +19,49 @@ export default function Season({season}: SeasonProps) {
 			title={`${season.year} Season`}
 			headerProps={{sx: {minWidth: 480}}}
 		>
-			<Grid container spacing={2} alignItems="stretch">
-				<Grid item xs={12} lg={8}>
-					<Grid container spacing={2} alignItems="stretch">
+			<div className="grid grid-cols-12 gap-4 items-stretch">
+				<div className="col-span-12 lg:col-span-8">
+					<div className="grid grid-cols-12 gap-4 items-stretch">
 						<Suspense><RaceWeekend season={season.year}/></Suspense>
-						<Grid item xs={12}>
+						<div className="col-span-12">
 							<Suspense fallback={<ScheduleSkeleton/>}>
 								<Schedule season={season.year}/>
 							</Suspense>
-						</Grid>
-					</Grid>
-				</Grid>
-				<Grid item xs={12} lg={4}>
-					<Grid container spacing={2}>
-						<Grid item xs={12}>
+						</div>
+					</div>
+				</div>
+				<div className="col-span-12 lg:col-span-4">
+					<div className="grid grid-cols-12 gap-4">
+						<div className="col-span-12">
 							<DriverStandings season={season.year}/>
-						</Grid>
-						<Grid item xs={12}>
+						</div>
+						<div className="col-span-12">
 							<TeamStandings season={season.year}/>
-						</Grid>
-						
-						<Grid item xs={12}>
+						</div>
+
+						<div className="col-span-12">
 							<Card>
 								<CardHeader title="Season Stats"/>
 								<CardContent>
-									<Grid container spacing={2}>
+									<div className="grid grid-cols-12 gap-4">
 										<Wins size="small" season={season.year}/>
 										<SprintWins size="small" season={season.year}/>
-										<Hidden lgUp><Grid item xs={12}/></Hidden>
+										<div className="block lg:hidden col-span-12"/>
 										<Poles size="small" season={season.year}/>
 										<FastestLaps season={season.year}/>
-										<Hidden lgUp><Grid item xs={12}/></Hidden>
+										<div className="block lg:hidden col-span-12"/>
 										<FastestLap season={season.year}/>
 										<LapLeader size="small" season={season.year}/>
-										<Hidden lgUp><Grid item xs={12}/></Hidden>
+										<div className="block lg:hidden col-span-12"/>
 										<PositionsGained size="small" season={season.year}/>
 										<DNFs size="small" season={season.year}/>
-									</Grid>
+									</div>
 								</CardContent>
 							</Card>
-						</Grid>
-					</Grid>
-				</Grid>
-			</Grid>
+						</div>
+					</div>
+				</div>
+			</div>
 		</Page>
 	);
 }

--- a/packages/site/src/components/ui/suspense/SuspendedTable.tsx
+++ b/packages/site/src/components/ui/suspense/SuspendedTable.tsx
@@ -1,4 +1,4 @@
-import {Box, Grid, Skeleton} from '@mui/material';
+import {Skeleton} from '@mui/material';
 import {ReactNode} from 'react';
 
 type SuspendedTableProps = {
@@ -7,16 +7,17 @@ type SuspendedTableProps = {
 	rowSkeleton?: ReactNode
 }
 const SuspendedTable = ({rows = 10, cols = 1, rowSkeleton}: SuspendedTableProps) => {
-	const fakeData: string[] = (new Array(rows * (!!rowSkeleton ? 1 : cols))).fill('');
-	
+	const totalCols          = !!rowSkeleton ? 1 : cols;
+	const fakeData: string[] = (new Array(rows * totalCols)).fill('');
+
 	return (
-		<Box sx={{p: 1}}>
-			<Grid container spacing={2} columns={!!rowSkeleton ? 1 : cols}>
-				{fakeData.map((_, i) => <Grid item xs={1} key={i}>
+		<div className="p-2">
+			<div className="grid gap-4" style={{gridTemplateColumns: `repeat(${totalCols}, minmax(0, 1fr))`}}>
+				{fakeData.map((_, i) => <div key={i}>
 					{rowSkeleton || <Skeleton variant="text" height="1.5em"/>}
-				</Grid>)}
-			</Grid>
-		</Box>
+				</div>)}
+			</div>
+		</div>
 	);
 };
 


### PR DESCRIPTION
## Summary

Track B / M3 — Layout primitives sweep. Migrate MUI layout components to Tailwind across packages/site/src.

Swaps (24 files):
- `<Box>` → `<div>`
- `<Stack>` → `<div className="flex flex-col gap-N">` (or `flex-row` per `direction`)
- `<Container maxWidth="X">` → `<div className="mx-auto max-w-X px-4">`
- `<Grid container spacing={N}>` → `<div className="grid grid-cols-12 gap-N">`
- `<Grid item xs={A} md={B}>` → `<div className="col-span-A md:col-span-B">`
- `<Hidden mdDown>` → `<div className="hidden md:block">`
- `<Hidden mdUp>` → `<div className="md:hidden">`
- `<Divider>` → `<div className="border-t my-2">` (or `border-l` if vertical)

`sx` for simple cases converted to Tailwind classes; consumers with `theme.spacing()`, MUI selectors, or nested `&` syntax kept on MUI for follow-up.

## Files migrated (24)

AboutContent, CircuitContent, ConstructorContent/DriverContent/RoundContent, ErrorBoundary, DriverByLine, ChartSwitcher, Header, NavMenu, MapTooltip, RaceMap, Stats, SeasonChart (driver), CareerPerformanceBurst, CircuitDialog, LapTimesByYearSwarm, Place, Podium, LapByLap, PitStopsChart, RaceWeekend, Season (race), SuspendedTable.

## Files deliberately skipped

Kept on MUI (complex sx, theme reads, or public-API surface for follow-up alongside their owning phase):
- Layout.tsx, CircuitMap.tsx, StatCard.tsx, StatCardContent.tsx, Page.tsx, TableFilter.tsx, NivoTooltipFactory.tsx

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec jest --no-coverage` — 22/22 pass
- [x] `pnpm --filter @gtibrett/effone-hub-site build` — full prerender
- [ ] Vercel preview visual smoke after merge into `feature/mui-shadcn-migration`
