### PR TITLE
Track B / M8: DataGrid → TanStack Table v8 + shadcn wrapper

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -81,6 +81,7 @@
 		"@nivo/sunburst": "^0.87.0",
 		"@nivo/swarmplot": "^0.87.0",
 		"@tailwindcss/postcss": "^4.3.0",
+		"@tanstack/react-table": "^8.21.3",
 		"adm-zip": "^0.5.17",
 		"animate.css": "^4.1.1",
 		"class-variance-authority": "^0.7.1",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -66,7 +66,6 @@
 		"@mui/material-nextjs": "^6",
 		"@mui/system": "^6",
 		"@mui/utils": "^6",
-		"@mui/x-data-grid": "^7",
 		"@next/third-parties": "^16.0.0",
 		"@nivo/axes": "^0.87.0",
 		"@nivo/bar": "^0.87.0",

--- a/packages/site/src/app/about/AboutContent.tsx
+++ b/packages/site/src/app/about/AboutContent.tsx
@@ -3,7 +3,7 @@
 import {Data, Dependencies, Mission, Repositories} from '@/components/page/about';
 import {Page} from '@/components/ui';
 import {Button as ShadcnButton} from '@/components/ui/shadcn/button';
-import {Button as MuiButton, Grid} from '@mui/material';
+import {Button as MuiButton} from '@mui/material';
 
 export default function AboutContent() {
 	return (
@@ -15,27 +15,27 @@ export default function AboutContent() {
 				<ShadcnButton>shadcn Button</ShadcnButton>
 				<MuiButton variant="contained">MUI Button</MuiButton>
 			</div>
-			<Grid container spacing={2}>
-				<Grid item xs={12} md={9}>
-					<Grid container spacing={2} alignItems="strech">
-						<Grid item xs={12}>
+			<div className="grid grid-cols-12 gap-4">
+				<div className="col-span-12 md:col-span-9">
+					<div className="grid grid-cols-12 gap-4 items-stretch">
+						<div className="col-span-12">
 							<Mission/>
-						</Grid>
+						</div>
 
-						<Grid item xs={12} md={6}>
+						<div className="col-span-12 md:col-span-6">
 							<Data/>
-						</Grid>
+						</div>
 
-						<Grid item xs={12} md={6}>
+						<div className="col-span-12 md:col-span-6">
 							<Repositories/>
-						</Grid>
-					</Grid>
-				</Grid>
+						</div>
+					</div>
+				</div>
 
-				<Grid item xs={12} md={3}>
+				<div className="col-span-12 md:col-span-3">
 					<Dependencies/>
-				</Grid>
-			</Grid>
+				</div>
+			</div>
 		</Page>
 	);
 }

--- a/packages/site/src/components/page/circuits/CircuitsList.tsx
+++ b/packages/site/src/components/page/circuits/CircuitsList.tsx
@@ -1,10 +1,10 @@
-import {Link} from '@/components/ui';
 import CircuitQuery from '@/components/page/circuits/CircuitsQuery';
 import {useCircuitsList} from '@/components/page/circuits/index';
 import {CircuitsListFilters} from '@/components/page/circuits/types';
+import {DataTable, Link} from '@/components/ui';
 import {Circuit} from '@/gql/graphql';
-import { useSuspenseQuery } from "@apollo/client/react";
-import {DataGrid} from '@mui/x-data-grid';
+import {useSuspenseQuery} from '@apollo/client/react';
+import type {ColumnDef} from '@tanstack/react-table';
 
 type CircuitsListProps = {
 	filters: CircuitsListFilters
@@ -14,39 +14,37 @@ export default function CircuitsList({filters}: CircuitsListProps) {
 	const {data: {circuits}} = useSuspenseQuery<{ circuits: { nodes: Circuit[] } }>(CircuitQuery);
 	const filteredCircuits   = useCircuitsList(circuits.nodes, filters);
 
-	return <DataGrid
-		rows={filteredCircuits}
-		autoHeight
-		density="compact"
-		getRowId={c => c.rowId}
-		columns={
-			[
-				{
-					field:      'name',
-					headerName: 'Circuit',
-					flex:       1,
-					renderCell: ({row}) => <Link href={`/circuits/${row.rowId}`}>{row.name}</Link>
-				},
-				{
-					field:      'country',
-					headerName: 'Location',
-					flex:       .75,
-					renderCell: ({row}) => `${row.placeName}, ${row.country}`
-				},
-				{
-					field:       'races',
-					headerName:  'Races',
-					headerAlign: 'right',
-					align:       'right',
-					flex:        .25,
-					valueGetter: (value, row) => row.races.nodes.length
-				}
-			]
+	const columns: ColumnDef<Circuit, any>[] = [
+		{
+			accessorKey: 'name',
+			header:      'Circuit',
+			cell:        ({row}) => <Link href={`/circuits/${row.original.rowId}`}>{row.original.name}</Link>
+		},
+		{
+			accessorKey: 'country',
+			header:      'Location',
+			cell:        ({row}) => `${row.original.placeName}, ${row.original.country}`
+		},
+		{
+			id:         'races',
+			header:     () => <div className="text-right w-full">Races</div>,
+			accessorFn: (row) => row.races.nodes.length,
+			cell:       ({getValue}) => <div className="text-right">{getValue<number>()}</div>
 		}
-		initialState={{
-			sorting: {
-				sortModel: [{field: 'circuitName', sort: 'asc'}]
-			}
-		}}
-	/>;
+	];
+
+	return (
+		<DataTable<Circuit>
+			rows={filteredCircuits}
+			columns={columns}
+			autoHeight
+			density="compact"
+			getRowId={(c: Circuit) => c.rowId}
+			initialState={{
+				sorting: {
+					sortModel: [{field: 'circuitName', sort: 'asc'}]
+				}
+			}}
+		/>
+	);
 }

--- a/packages/site/src/components/page/circuits/History.tsx
+++ b/packages/site/src/components/page/circuits/History.tsx
@@ -1,9 +1,9 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
-import {Link} from '@/components/ui';
 import {DriverByLine} from '@/components/app';
 import {CircuitDataProps} from '@/hooks/data';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable, Link} from '@/components/ui';
 import {Skeleton} from '@mui/material';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 
 export default function History({data, loading}: CircuitDataProps) {
 	if (loading) {
@@ -14,78 +14,68 @@ export default function History({data, loading}: CircuitDataProps) {
 		return <Alert><AlertDescription>Race Data Not Available</AlertDescription></Alert>;
 	}
 
+	type Row = (typeof data.circuit.history.nodes)[number];
+
+	const columns: ColumnDef<Row, any>[] = [
+		{
+			accessorKey: 'year',
+			header:      () => <div className="text-center w-full">Season</div>,
+			size:        100,
+			cell:        ({row}) => <div className="text-center"><Link href={`/${row.original.year}`}>{row.original.year}</Link></div>
+		},
+		{
+			id:         'date',
+			header:     () => <div className="text-center w-full">Date</div>,
+			accessorFn: (row) => row.date ? new Date(row.date) : undefined,
+			sortingFn:  'datetime',
+			cell:       ({getValue}) => {
+				const value = getValue<Date | undefined>();
+				return <div className="text-center">{value ? value.toLocaleDateString() : ''}</div>;
+			}
+		},
+		{
+			accessorKey: 'officialName',
+			header:      'Race',
+			cell:        ({row}) => (
+				<Link href={`/${row.original.year}/${row.original.round}#${row.original.officialName}`}>{row.original.year} {row.original.officialName}</Link>
+			)
+		},
+		{
+			id:         'winner',
+			header:     'Winner',
+			accessorFn: (row) => {
+				if (!row.raceResults?.nodes?.length) {
+					return '--';
+				}
+				return `${row.raceResults?.nodes?.[0]?.driver?.lastName}, ${row.raceResults?.nodes?.[0]?.driver?.firstName}`;
+			},
+			cell:       ({row}) => {
+				if (!row.original.raceResults?.nodes?.length) {
+					return '--';
+				}
+				return <DriverByLine id={row.original.raceResults?.nodes?.[0]?.driverId}/>;
+			}
+		},
+		{
+			id:            'time',
+			header:        'Time',
+			enableSorting: false,
+			cell:          ({row}) => row.original.raceResults?.nodes?.[0]?.time || '--'
+		}
+	];
+
 	return (
-		<DataGrid
-			rows={data.circuit.history.nodes}
+		<DataTable<Row>
+			rows={data.circuit.history.nodes as Row[]}
+			columns={columns}
 			autoHeight
 			density="compact"
-			getRowId={r => r.date}
+			getRowId={(r: Row) => r.date}
 			initialState={{
 				sorting: {
 					sortModel: [{field: 'year', sort: 'desc'}]
 				}
 			}}
-			columns={
-				[
-					{
-						field:       'year',
-						headerName:  'Season',
-						headerAlign: 'center',
-						align:       'center',
-						width:       100,
-						renderCell:  ({row}) => <Link href={`/${row.year}`}>{row.year}</Link>
-					},
-					{
-						field:       'date',
-						headerName:  'Date',
-						headerAlign: 'center',
-						type:        'date',
-						align:       'center',
-						valueGetter: (value) => (new Date(value)),
-						renderCell:  ({value}) => value.toLocaleDateString(),
-						minWidth:    100
-					},
-					{
-						field:      'officialName',
-						headerName: 'Race',
-						flex:       1,
-						renderCell: ({row}) => (
-							<Link href={`/${row.year}/${row.round}#${row.officialName}`}>{row.year} {row.officialName}</Link>
-						),
-						minWidth:   200
-					},
-					{
-						field:       'winner',
-						headerName:  'Winner',
-						flex:        1,
-						valueGetter: (value, row) => {
-							if (!row.raceResults?.nodes?.length) {
-								return '--';
-							}
-
-							return `${row.raceResults?.nodes?.[0]?.driver?.lastName}, ${row.raceResults?.nodes?.[0]?.driver?.firstName}`;
-						},
-						renderCell:  ({row}) => {
-							if (!row.raceResults?.nodes?.length) {
-								return '--';
-							}
-
-							return <DriverByLine id={row.raceResults?.nodes?.[0]?.driverId}/>;
-						},
-						minWidth:    200
-					},
-					{
-						field:       'time',
-						headerName:  'Time',
-						sortable:    false,
-						headerAlign: 'left',
-						align:       'left',
-						flex:        .5,
-						renderCell:  ({row}) => row.raceResults?.nodes?.[0]?.time || '--',
-						minWidth:    110
-					}
-				]
-			}
 		/>
 	);
 }

--- a/packages/site/src/components/page/circuits/Season.tsx
+++ b/packages/site/src/components/page/circuits/Season.tsx
@@ -1,9 +1,10 @@
 import {ConstructorByLine, DriverByLine} from '@/components/app';
 import {getPositionTextOutcome} from '@/helpers';
 import {CircuitDataProps} from '@/hooks/data';
+import {DataTable} from '@/components/ui';
 import {Grid, Skeleton, Typography} from '@mui/material';
 import {visuallyHidden} from '@mui/utils';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import PositionChange from '../race/PositionChange';
 import NextRaceCountdown from '../raceWeekend/NextRaceCountdown';
 
@@ -11,11 +12,11 @@ export default function Season({data, loading}: CircuitDataProps) {
 	if (loading) {
 		return <Skeleton variant="rectangular" height={400}/>;
 	}
-	
+
 	if (!data) {
 		return null;
 	}
-	
+
 	if (data.circuit.season.nodes.length) {
 		if (!data.circuit.season.nodes[0].raceResults.nodes.length) {
 			return <>
@@ -26,86 +27,76 @@ export default function Season({data, loading}: CircuitDataProps) {
 	}
 
 	const results = (data.circuit.season.nodes[0].raceResults.nodes).filter(Boolean) as NonNullable<typeof data.circuit.season.nodes[0]['raceResults']['nodes'][number]>[];
-	
+	type Row = (typeof results)[number];
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<Row, any>[] = [
+		{
+			accessorKey: 'positionDisplayOrder',
+			header:      numHeader('P'),
+			size:        60,
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			id:         'change',
+			header:     () => <Typography sx={visuallyHidden}>Position Changes</Typography>,
+			size:       60,
+			accessorFn: (row) => {
+				const {gridPositionNumber, positionDisplayOrder} = row;
+				if (!gridPositionNumber || !positionDisplayOrder) {
+					return 0;
+				}
+				return Number(gridPositionNumber) - Number(positionDisplayOrder);
+			},
+			cell:       ({row}) => (
+				<div className="text-center">
+					<PositionChange gridPositionNumber={Number(row.original.gridPositionNumber)} positionDisplayOrder={Number(row.original.positionDisplayOrder)}/>
+				</div>
+			)
+		},
+		{
+			id:     'Driver',
+			header: 'Driver',
+			cell:   ({row}) => row.original.driverId ? <DriverByLine id={row.original.driverId}/> : ''
+		},
+		{
+			id:     'Constructor',
+			header: 'Constructor',
+			cell:   ({row}) => row.original.team?.rowId ? <ConstructorByLine id={row.original.team.rowId}/> : ''
+		},
+		{
+			accessorKey: 'points',
+			header:      numHeader('Points'),
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			accessorKey:   'reasonRetired',
+			header:        'Status',
+			enableSorting: false,
+			cell:          ({row}) => {
+				return (
+					<Grid container alignItems="center" justifyContent="space-between" flexWrap="nowrap" spacing={1}>
+						<Grid item><>{row.original.reasonRetired ? row.original.reasonRetired : getPositionTextOutcome(String(row.original.positionDisplayOrder), undefined)}</>
+						</Grid>
+					</Grid>
+				);
+			}
+		}
+	];
+
 	return (
-		<DataGrid
+		<DataTable<Row>
 			rows={results}
+			columns={columns}
 			autoHeight
 			density="compact"
-			getRowId={r => r.driverId || ''}
+			getRowId={(r: Row) => r.driverId || ''}
 			initialState={{
 				sorting: {
 					sortModel: [{field: 'positionDisplayOrder', sort: 'asc'}]
 				}
 			}}
-			columns={
-				[
-					{
-						field:       'positionDisplayOrder',
-						headerName:  'P',
-						width:       60,
-						headerAlign: 'center',
-						align:       'center',
-						type:        'number'
-					},
-					{
-						field:        'change',
-						renderHeader: () => <Typography sx={visuallyHidden}>Position Changes</Typography>,
-						renderCell:   ({row}) => (
-							<PositionChange gridPositionNumber={Number(row.gridPositionNumber)} positionDisplayOrder={Number(row.positionDisplayOrder)}/>
-						),
-						valueGetter:  (value, row) => {
-							const {gridPositionNumber, positionDisplayOrder} = row;
-							if (!gridPositionNumber || !positionDisplayOrder) {
-								return 0;
-							}
-
-							return Number(gridPositionNumber) - Number(positionDisplayOrder);
-						},
-						width:        60,
-						headerAlign:  'center',
-						align:        'center'
-					},
-					{
-						field:      'Driver',
-						headerName: 'Driver',
-						flex:       1,
-						renderCell: ({row}) => row.driverId ? <DriverByLine id={row.driverId}/> : '',
-						minWidth:   200
-					},
-					{
-						field:      'Constructor',
-						headerName: 'Constructor',
-						flex:       1,
-						renderCell: ({row}) => row.team?.rowId ? <ConstructorByLine id={row.team.rowId}/> : '',
-						minWidth:   150
-					},
-					{
-						field:       'points',
-						headerName:  'Points',
-						type:        'number',
-						headerAlign: 'center',
-						align:       'center'
-					},
-					{
-						field:       'reasonRetired',
-						headerName:  'Status',
-						sortable:    false,
-						headerAlign: 'left',
-						align:       'left',
-						flex:        .5,
-						renderCell:  ({row}) => {
-							return (
-								<Grid container alignItems="center" justifyContent="space-between" flexWrap="nowrap" spacing={1}>
-									<Grid item><>{row.reasonRetired ? row.reasonRetired : getPositionTextOutcome(String(row.positionDisplayOrder), undefined)}</>
-									</Grid>
-								</Grid>
-							);
-						},
-						minWidth:    110
-					}
-				]
-			}
 		/>
 	);
 }

--- a/packages/site/src/components/page/constructor/ConstructorsList.tsx
+++ b/packages/site/src/components/page/constructor/ConstructorsList.tsx
@@ -2,11 +2,12 @@ import '@/polyfills';
 import {ConstructorByLine} from '@/components/app';
 import {ConstructorsListFilters, ConstructorsQuery, useConstructorsList} from '@/components/page/constructor/index';
 import {useGetTeamColor} from '@/hooks';
-import { useSuspenseQuery } from "@apollo/client/react";
+import {useSuspenseQuery} from '@apollo/client/react';
 import {faSquareFull} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {DataGrid} from '@mui/x-data-grid';
+import {DataTable} from '@/components/ui';
 import {RaceResult} from '@/gql/graphql';
+import type {ColumnDef} from '@tanstack/react-table';
 import {TeamWithSeasons} from './useConstructorsList';
 
 type ConstructorsTableProps = {
@@ -17,65 +18,56 @@ export default function ConstructorsList({filters}: ConstructorsTableProps) {
 	const {data: {teams}} = useSuspenseQuery<{ teams: { nodes: TeamWithSeasons[] } }>(ConstructorsQuery);
 	const filteredTeams   = useConstructorsList(teams.nodes, filters);
 	const getTeamColor    = useGetTeamColor();
-	
+
+	const numCell = (v: unknown) => <div className="text-right">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-right w-full">{label}</div>;
+
+	const columns: ColumnDef<TeamWithSeasons, any>[] = [
+		{
+			id:            'color',
+			header:        '',
+			size:          24,
+			enableSorting: false,
+			cell:          ({row}) => <FontAwesomeIcon icon={faSquareFull} color={getTeamColor(row.original.colors, 'primaryHex', false)}/>
+		},
+		{
+			accessorKey: 'name',
+			header:      'Constructor',
+			cell:        ({row}) => <ConstructorByLine team={row.original} variant="link"/>
+		},
+		{
+			id:         'seasons',
+			header:     numHeader('Seasons'),
+			accessorFn: (row) => (row.seasons?.nodes ?? []).map((s: { year: number }) => s.year).distinct().length,
+			cell:       ({getValue}) => numCell(getValue())
+		},
+		{
+			id:         'races',
+			header:     numHeader('Races'),
+			accessorFn: (row) => row.raceResults?.nodes.filter((r: any): r is RaceResult => r != null).map((r: any) => `${r.raceId}-${r.driverId}`).distinct().length,
+			cell:       ({getValue}) => numCell(getValue())
+		},
+		{
+			id:         'wins',
+			header:     numHeader('Wins'),
+			accessorFn: (row) => row.raceResults?.nodes.filter((r: any): r is RaceResult => r != null).filter((r: { positionNumber?: number | null }) => Number(r.positionNumber) === 1).length,
+			cell:       ({getValue}) => numCell(getValue())
+		},
+		{
+			id:         'podiums',
+			header:     numHeader('Podiums'),
+			accessorFn: (row) => row.raceResults?.nodes.filter((r: any): r is RaceResult => r != null).filter((r: { positionNumber?: number | null }) => Number(r.positionNumber) <= 3).length,
+			cell:       ({getValue}) => numCell(getValue())
+		}
+	];
+
 	return (
-		<DataGrid
+		<DataTable<TeamWithSeasons>
 			rows={filteredTeams}
+			columns={columns}
 			autoHeight
 			density="compact"
-			getRowId={r => r.id}
-			columns={
-				[
-					{
-						field:      'color',
-						headerName: '',
-						width:      24,
-						renderCell: (({row}) => <FontAwesomeIcon icon={faSquareFull} color={getTeamColor(row.colors, 'primaryHex', false)}/>),
-						sortable:   false
-					},
-					{
-						field:      'name',
-						headerName: 'Constructor',
-						flex:       1,
-						renderCell: ({row}) => <ConstructorByLine team={row} variant="link"/>
-					},
-					{
-						field:       'seasons',
-						headerName:  'Seasons',
-						flex:        .25,
-						type:        'number',
-						valueGetter: (_, row) => (row.seasons?.nodes ?? []).map((s: { year: number }) => s.year).distinct().length
-					},
-					{
-						field:       'races',
-						headerName:  'Races',
-						flex:        .25,
-						type:        'number',
-						valueGetter: (_, row) => row.raceResults?.nodes.filter((r): r is RaceResult => r != null).map((r) => `${r.raceId}-${r.driverId}`).distinct().length
-					},
-					// {
-					// 	field:       'championships',
-					// 	headerName:  'Championships',
-					// 	flex:        .25,
-					// 	type:        'number',
-					// 	valueGetter: (value, row) => row.driverStandingsBySeasons.filter(r=>Number(r.position) === 1).length
-					// },
-					{
-						field:       'wins',
-						headerName:  'Wins',
-						flex:        .25,
-						type:        'number',
-						valueGetter: (value, row) => row.raceResults?.nodes.filter((r): r is RaceResult => r != null).filter((r: { positionNumber?: number | null }) => Number(r.positionNumber) === 1).length
-					},
-					{
-						field:       'podiums',
-						headerName:  'Podiums',
-						flex:        .25,
-						type:        'number',
-						valueGetter: (value, row) => row.raceResults?.nodes.filter((r): r is RaceResult => r != null).filter((r: { positionNumber?: number | null }) => Number(r.positionNumber) <= 3).length
-					}
-				]
-			}
+			getRowId={(r: TeamWithSeasons) => r.id}
 			initialState={{
 				sorting: {
 					sortModel: [{field: 'name', sort: 'asc'}]

--- a/packages/site/src/components/page/constructor/Drivers.tsx
+++ b/packages/site/src/components/page/constructor/Drivers.tsx
@@ -1,10 +1,10 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
-import {Link} from '@/components/ui';
 import {DriverByLine} from '@/components/app';
 import type {SimpleApolloResult} from '@/app/lib/apollo-types';
 import {SeasonDriverStanding} from '@/gql/graphql';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable, Link} from '@/components/ui';
 import {Skeleton} from '@mui/material';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import {ConstructorPageData, DriverByYear} from './types';
 
 type DriversProps = SimpleApolloResult<ConstructorPageData>;
@@ -15,7 +15,7 @@ type RowData = {
 }
 
 const findFinalStandings = (year: number, standings: SeasonDriverStanding[]) => {
-	return standings.filter(s => s.year === year)[0];
+	return standings.filter((s) => s.year === year)[0];
 };
 
 export default function Drivers({data, loading}: DriversProps) {
@@ -23,98 +23,80 @@ export default function Drivers({data, loading}: DriversProps) {
 		return <Skeleton variant="rectangular" height={400}/>;
 	}
 	const years: RowData[] = [];
-	
-	(data?.team.drivers.nodes || []).forEach(dy => {
-		let index = years.findIndex(y => y.year === dy.year);
-		
+
+	(data?.team.drivers.nodes || []).forEach((dy) => {
+		let index = years.findIndex((y) => y.year === dy.year);
+
 		if (index === -1) {
 			years.push({
 				year:    dy.year,
 				drivers: []
 			});
-			
+
 			index = years.length - 1;
 		}
-		
+
 		years[index].drivers.push(dy.driver);
 	});
-	
+
 	if (!years.length) {
 		return <Alert><AlertDescription>Career Data Not Available</AlertDescription></Alert>;
 	}
-	
-	return (
-		<>
-			<DataGrid
-				rows={years}
-				autoHeight
-				density="compact"
-				getRowId={(r) => r.year}
-				initialState={{
-					sorting: {
-						sortModel: [{field: 'year', sort: 'desc'}]
-					}
-				}}
-				columns={
-					[
-						{
-							field:       'year',
-							headerName:  'Season',
-							headerAlign: 'center',
-							align:       'center',
-							width:       100,
-							renderCell:  ({row}) => <Link href={`/seasons/${row.year}`}>{row.year}</Link>
-						},
-						{
-							field:      'driver1',
-							headerName: 'Driver',
-							flex:       1,
-							minWidth:   175,
-							renderCell: ({row}) => row.drivers[0] ? <DriverByLine id={row.drivers[0].id} variant="full"/> : ''
-						},
-						{
-							field:       'standing1',
-							headerName:  'Standing',
-							type:        'number',
-							headerAlign: 'center',
-							align:       'center',
-							renderCell:  ({row}) => row.drivers[0] ? findFinalStandings(row.year, row.drivers[0].seasonDriverStandings?.nodes?.filter((s): s is SeasonDriverStanding => s != null))?.positionNumber : ''
-						},
 
-						{
-							field:       'points1',
-							headerName:  'Points',
-							type:        'number',
-							headerAlign: 'center',
-							align:       'center',
-							renderCell:  ({row}) => row.drivers[0] ? findFinalStandings(row.year, row.drivers[0].seasonDriverStandings?.nodes?.filter((s): s is SeasonDriverStanding => s != null))?.points : ''
-						},
-						{
-							field:      'driver2',
-							headerName: 'Driver',
-							flex:       1,
-							minWidth:   175,
-							renderCell: ({row}) => row.drivers[1] ? <DriverByLine id={row.drivers[1].id} variant="full"/> : ''
-						},
-						{
-							field:       'standing2',
-							headerName:  'Standing',
-							type:        'number',
-							headerAlign: 'center',
-							align:       'center',
-							renderCell:  ({row}) => row.drivers[1] ? findFinalStandings(row.year, row.drivers[1].seasonDriverStandings?.nodes?.filter((s): s is SeasonDriverStanding => s != null))?.positionNumber : ''
-						},
-						{
-							field:       'points2',
-							headerName:  'Points',
-							type:        'number',
-							headerAlign: 'center',
-							align:       'center',
-							renderCell:  ({row}) => row.drivers[1] ? findFinalStandings(row.year, row.drivers[1].seasonDriverStandings?.nodes?.filter((s): s is SeasonDriverStanding => s != null))?.points : ''
-						}
-					]
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<RowData, any>[] = [
+		{
+			accessorKey: 'year',
+			header:      numHeader('Season'),
+			size:        100,
+			cell:        ({row}) => <div className="text-center"><Link href={`/seasons/${row.original.year}`}>{row.original.year}</Link></div>
+		},
+		{
+			id:     'driver1',
+			header: 'Driver',
+			cell:   ({row}) => row.original.drivers[0] ? <DriverByLine id={row.original.drivers[0].id} variant="full"/> : ''
+		},
+		{
+			id:     'standing1',
+			header: numHeader('Standing'),
+			cell:   ({row}) => numCell(row.original.drivers[0] ? findFinalStandings(row.original.year, row.original.drivers[0].seasonDriverStandings?.nodes?.filter((s: any): s is SeasonDriverStanding => s != null))?.positionNumber : '')
+		},
+		{
+			id:     'points1',
+			header: numHeader('Points'),
+			cell:   ({row}) => numCell(row.original.drivers[0] ? findFinalStandings(row.original.year, row.original.drivers[0].seasonDriverStandings?.nodes?.filter((s: any): s is SeasonDriverStanding => s != null))?.points : '')
+		},
+		{
+			id:     'driver2',
+			header: 'Driver',
+			cell:   ({row}) => row.original.drivers[1] ? <DriverByLine id={row.original.drivers[1].id} variant="full"/> : ''
+		},
+		{
+			id:     'standing2',
+			header: numHeader('Standing'),
+			cell:   ({row}) => numCell(row.original.drivers[1] ? findFinalStandings(row.original.year, row.original.drivers[1].seasonDriverStandings?.nodes?.filter((s: any): s is SeasonDriverStanding => s != null))?.positionNumber : '')
+		},
+		{
+			id:     'points2',
+			header: numHeader('Points'),
+			cell:   ({row}) => numCell(row.original.drivers[1] ? findFinalStandings(row.original.year, row.original.drivers[1].seasonDriverStandings?.nodes?.filter((s: any): s is SeasonDriverStanding => s != null))?.points : '')
+		}
+	];
+
+	return (
+		<DataTable<RowData>
+			rows={years}
+			columns={columns}
+			autoHeight
+			density="compact"
+			getRowId={(r: RowData) => r.year}
+			initialState={{
+				sorting: {
+					sortModel: [{field: 'year', sort: 'desc'}]
 				}
-			/>
-		</>
+			}}
+		/>
 	);
 }

--- a/packages/site/src/components/page/constructor/history/History.tsx
+++ b/packages/site/src/components/page/constructor/history/History.tsx
@@ -1,9 +1,9 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
-import {Link} from '@/components/ui';
 import {ChartSwitcher, ChartSwitcherChart} from '@/components/app';
 import type {SimpleApolloResult} from '@/app/lib/apollo-types';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable, Link} from '@/components/ui';
 import {Skeleton} from '@mui/material';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import {ConstructorPageData} from '../types';
 import HistoryChart from './HistoryChart';
 
@@ -13,18 +13,22 @@ export default function History({data, loading}: HistoryProps) {
 	if (loading) {
 		return <Skeleton variant="rectangular" height={400}/>;
 	}
-	const standings = data?.team?.standings.nodes.map(s => ({...s, name: data?.team.name})) || [];
+	const standings = data?.team?.standings.nodes.map((s) => ({...s, name: data?.team.name})) || [];
 
 	data?.team.antecedents.nodes.forEach(({antecedentTeam, startYear, endYear}) => {
 		antecedentTeam.standings
-		              .filter(s => s.year && s.year >= (startYear ?? 0) && (!endYear || s.year <= endYear))
-		              .forEach(s => standings.push({...s, name: antecedentTeam.name}));
+		              .filter((s) => s.year && s.year >= (startYear ?? 0) && (!endYear || s.year <= endYear))
+		              .forEach((s) => standings.push({...s, name: antecedentTeam.name}));
 	});
-	
+
 	if (!standings.length) {
 		return <Alert><AlertDescription>Career Data Not Available</AlertDescription></Alert>;
 	}
-	
+
+	type Row = (typeof standings)[number];
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
 	const charts: ChartSwitcherChart[] = [
 		{
 			id:    'position',
@@ -37,55 +41,44 @@ export default function History({data, loading}: HistoryProps) {
 			chart: <HistoryChart data={data} loading={loading} dataKey="points" dataMaxKey="maxPoints"/>
 		}
 	];
-	
+
+	const columns: ColumnDef<Row, any>[] = [
+		{
+			accessorKey: 'year',
+			header:      numHeader('Season'),
+			size:        100,
+			cell:        ({row}) => <div className="text-center"><Link href={`/seasons/${row.original.year}`}>{row.original.year}</Link></div>
+		},
+		{
+			accessorKey: 'name',
+			header:      'Name'
+		},
+		{
+			accessorKey: 'positionNumber',
+			header:      numHeader('Position'),
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			accessorKey: 'points',
+			header:      numHeader('Points'),
+			cell:        ({getValue}) => numCell(getValue())
+		}
+	];
+
 	return (
 		<>
 			<ChartSwitcher title="Constructor Timeline" size={250} charts={charts}/>
-			
-			<DataGrid
+			<DataTable<Row>
 				rows={standings}
+				columns={columns}
 				autoHeight
 				density="compact"
-				getRowId={(r) => `${r.year}-${r.name}` || ''}
+				getRowId={(r: Row) => `${r.year}-${r.name}` || ''}
 				initialState={{
 					sorting: {
 						sortModel: [{field: 'year', sort: 'desc'}]
 					}
 				}}
-				columns={
-					[
-						{
-							field:       'year',
-							headerName:  'Season',
-							headerAlign: 'center',
-							align:       'center',
-							width:       100,
-							renderCell:  ({row}) => <Link href={`/seasons/${row.year}`}>{row.year}</Link>
-						},
-						{
-							field:      'name',
-							headerName: 'Name',
-							flex:       1
-						},
-						{
-							field:       'positionNumber',
-							headerName:  'Position',
-							type:        'number',
-							headerAlign: 'center',
-							align:       'center',
-							flex:        .5
-						},
-						{
-							field:       'points',
-							headerName:  'Points',
-							type:        'number',
-							headerAlign: 'center',
-							align:       'center',
-							flex:        .5
-						}
-					
-					]
-				}
 			/>
 		</>
 	);

--- a/packages/site/src/components/page/constructor/season/Season.tsx
+++ b/packages/site/src/components/page/constructor/season/Season.tsx
@@ -1,9 +1,9 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
-import {Link} from '@/components/ui';
 import {DriverByLine} from '@/components/app';
 import type {SimpleApolloResult} from '@/app/lib/apollo-types';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable, Link} from '@/components/ui';
 import {Grid, Skeleton, Typography, TypographyProps} from '@mui/material';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import {PropsWithChildren} from 'react';
 import {ConstructorPageData} from '../types';
 import SeasonChart from './SeasonChart';
@@ -13,100 +13,102 @@ const CellValueWrapper = ({align = 'center', children}: PropsWithChildren<Pick<T
 type SeasonProps = SimpleApolloResult<ConstructorPageData> & { season: number };
 
 export default function Season({data, loading, season}: SeasonProps) {
-	
+
 	if (loading || !data) {
 		return <Skeleton variant="rectangular" height={400}/>;
 	}
-	
+
 	const races   = data.races.nodes;
 	const results = data.team.raceResults.nodes;
-	
+
 	if (!races?.length) {
 		return <Alert><AlertDescription>Season Data Not Available</AlertDescription></Alert>;
 	}
-	
+
+	type Row = (typeof races)[number];
+	const centerHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<Row, any>[] = [
+		{
+			id:         'date',
+			header:     centerHeader('Date'),
+			accessorFn: (row) => row.date ? new Date(row.date) : undefined,
+			sortingFn:  'datetime',
+			cell:       ({getValue}) => {
+				const value = getValue<Date | undefined>();
+				return <div className="text-center">{value ? value.toLocaleDateString() : ''}</div>;
+			}
+		},
+		{
+			accessorKey: 'officialName',
+			header:      'Race',
+			cell:        ({row}) => (
+				<Link href={`/${season}/${row.original.round}#${row.original.officialName}`}>{row.original.officialName}</Link>
+			)
+		},
+		{
+			id:     'driver',
+			header: 'Drivers',
+			cell:   ({row}) => (
+				<>
+					{results.filter((r) => r.raceId === row.original.rowId).map((result) => (
+						<CellValueWrapper key={result.driverId ?? undefined} align="left">
+							<DriverByLine id={result.driverId ?? undefined} variant="link"/>
+						</CellValueWrapper>
+					))}
+				</>
+			)
+		},
+		{
+			id:     'qualifying',
+			header: centerHeader('Qualifying'),
+			cell:   ({row}) => (
+				<>
+					{results.filter((r) => r.raceId === row.original.rowId).map((result) => (
+						<CellValueWrapper key={result.driverId ?? ''}>{result.gridPositionNumber}</CellValueWrapper>
+					))}
+				</>
+			)
+		},
+		{
+			id:     'finish',
+			header: centerHeader('Finish'),
+			cell:   ({row}) => (
+				<>
+					{results.filter((r) => r.raceId === row.original.rowId).map((result) => (
+						<CellValueWrapper key={result.driverId ?? ''}>{result.positionNumber}</CellValueWrapper>
+					))}
+				</>
+			)
+		},
+		{
+			id:     'points',
+			header: centerHeader('Points'),
+			cell:   ({row}) => (
+				<Grid container spacing={0} justifyContent="center">
+					{results.filter((r) => r.raceId === row.original.rowId).map((result) => (
+						<Grid item xs={12} key={result.driverId ?? ''}><Typography align="center">{result.points}</Typography></Grid>
+					))}
+				</Grid>
+			)
+		}
+	];
+
 	return (
 		<>
 			<SeasonChart data={data} loading={loading} season={season}/>
-			<DataGrid
+			<DataTable<Row>
 				rows={races}
+				columns={columns}
 				rowHeight={100}
 				autoHeight
 				density="compact"
-				getRowId={(row) => row.round || ''}
+				getRowId={(row: Row) => row.round || ''}
 				initialState={{
 					sorting: {
 						sortModel: [{field: 'date', sort: 'asc'}]
 					}
 				}}
-				columns={
-					[
-						{
-							field:       'date',
-							headerName:  'Date',
-							headerAlign: 'center',
-							type:        'date',
-							align:       'center',
-							valueGetter: (value) => (new Date(value)),
-							renderCell:  ({value}) => value.toLocaleDateString()
-						},
-						{
-							field:      'officialName',
-							headerName: 'Race',
-							flex:       1,
-							renderCell: ({row, value}) => (
-								<Link href={`/${season}/${row.round}#${row.officialName}`}>{value}</Link>
-							)
-						},
-						{
-							field:      'driver',
-							headerName: 'Drivers',
-							flex:       1,
-							renderCell: ({row}) => (
-								<>
-									{
-										results.filter(r => r.raceId === row.rowId).map(result => <CellValueWrapper key={result.driverId ?? undefined} align="left"><DriverByLine id={result.driverId ?? undefined} variant="link"/></CellValueWrapper>)
-									}
-								</>
-							)
-						},
-						{
-							field:       'qualifying',
-							headerName:  'Qualifying',
-							headerAlign: 'center',
-							align:       'center',
-							renderCell:  ({row}) => (
-								<>
-									{
-										results.filter(r => r.raceId === row.rowId).map(result => <CellValueWrapper key={result.driverId ?? ''}>{result.gridPositionNumber}</CellValueWrapper>)
-									}
-								</>
-							)
-						},
-						{
-							field:       'finish',
-							headerName:  'Finish',
-							headerAlign: 'center',
-							align:       'center',
-							renderCell:  ({row}) => {
-								return <>
-									{results.filter(r => r.raceId === row.rowId).map(result => <CellValueWrapper key={result.driverId ?? ''}>{result.positionNumber}</CellValueWrapper>)}
-								</>;
-							}
-						},
-						{
-							field:       'points',
-							headerName:  'Points',
-							headerAlign: 'center',
-							align:       'center',
-							renderCell:  ({row}) => {
-								return <Grid container spacing={0} justifyContent="center">
-									{results.filter(r => r.raceId === row.rowId).map(result => <Grid item xs={12} key={result.driverId ?? ''}><Typography align="center">{result.points}</Typography></Grid>)}
-								</Grid>;
-							}
-						}
-					]
-				}
 			/>
 		</>
 	);

--- a/packages/site/src/components/page/driver/DriversList.tsx
+++ b/packages/site/src/components/page/driver/DriversList.tsx
@@ -2,12 +2,12 @@ import {DriverAvatar, DriverByLine} from '@/components/app';
 import DriversQuery from '@/components/page/driver/DriversQuery';
 import {useDriversList} from '@/components/page/driver/index';
 import {DriversListFilters} from '@/components/page/driver/types';
-import {Flag} from '@/components/ui';
+import {DataTable, Flag} from '@/components/ui';
 import {Driver} from '@/gql/graphql';
-import { useSuspenseQuery } from "@apollo/client/react";
+import {useSuspenseQuery} from '@apollo/client/react';
 import {Grid, Typography} from '@mui/material';
 import {visuallyHidden} from '@mui/utils';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 
 type DriversTableProps = {
 	filters: DriversListFilters
@@ -16,78 +16,67 @@ type DriversTableProps = {
 export default function DriversList({filters}: DriversTableProps) {
 	const {data: {drivers}} = useSuspenseQuery<{ drivers: { nodes: Driver[] } }>(DriversQuery);
 	const filteredDrivers   = useDriversList(drivers.nodes, filters);
-	
+
+	const columns: ColumnDef<Driver, any>[] = [
+		{
+			id:            'avatar',
+			header:        () => <Typography sx={visuallyHidden}>Photo</Typography>,
+			cell:          ({row}) => <DriverAvatar driverId={row.original.id}/>,
+			size:          50,
+			enableSorting: false
+		},
+		{
+			id:         'driver',
+			header:     'Driver',
+			accessorFn: (row) => `${row.firstName}, ${row.lastName}`,
+			cell:       ({row}) => <DriverByLine driver={row.original} variant="link"/>
+		},
+		{
+			accessorKey: 'nationalityCountryId',
+			header:      'Nationality',
+			cell:        ({getValue}) => {
+				const value = getValue<string>();
+				return (
+					<Grid container spacing={1}>
+						<Grid item><Flag nationality={value}/></Grid>
+						<Grid item>{value}</Grid>
+					</Grid>
+				);
+			}
+		},
+		{
+			id:         'seasons',
+			header:     'Seasons',
+			accessorFn: (row) => row.seasonEntrantDrivers?.nodes?.length ?? 0,
+			cell:       ({getValue}) => <div className="text-right">{getValue<number>()}</div>
+		},
+		{
+			id:         'races',
+			header:     'Races',
+			accessorFn: (row) => row.raceResults?.nodes?.length ?? 0,
+			cell:       ({getValue}) => <div className="text-right">{getValue<number>()}</div>
+		},
+		{
+			id:         'wins',
+			header:     'Wins',
+			accessorFn: (row) => (row.raceResults?.nodes ?? []).filter((r: any) => Number(r.positionOrder) === 1).length,
+			cell:       ({getValue}) => <div className="text-right">{getValue<number>()}</div>
+		},
+		{
+			id:         'podiums',
+			header:     'Podiums',
+			accessorFn: (row) => (row.raceResults?.nodes ?? []).filter((r: any) => Number(r.positionOrder) <= 3).length,
+			cell:       ({getValue}) => <div className="text-right">{getValue<number>()}</div>
+		}
+	];
+
 	return (
-		<DataGrid
+		<DataTable<Driver>
 			rows={filteredDrivers}
+			columns={columns}
 			autoHeight
 			density="compact"
-			getRowId={r => r.id}
-			columns={
-				[
-					{
-						field:        'avatar',
-						renderHeader: () => <Typography sx={visuallyHidden}>Photo</Typography>,
-						renderCell:   (({row}) => <DriverAvatar driverId={row.id}/>),
-						width:        50,
-						align:        'center',
-						sortable:     false
-					},
-					{
-						field:       'driver',
-						headerName:  'Driver',
-						flex:        1,
-						renderCell:  (({row}) => <DriverByLine driver={row} variant="link"/>),
-						valueGetter: (value, row) => `${row.firstName}, ${row.lastName}`
-					},
-					{
-						field:      'nationalityCountryId',
-						headerName: 'Nationality',
-						flex:       1,
-						renderCell: ({value}) => (
-							<Grid container spacing={1}>
-								<Grid item><Flag nationality={value}/></Grid>
-								<Grid item>{value}</Grid>
-							</Grid>
-						)
-					},
-					{
-						field:       'seasons',
-						headerName:  'Seasons',
-						flex:        .25,
-						type:        'number',
-						valueGetter: (value, row) => row.seasonEntrantDrivers?.nodes?.length ?? 0
-					},
-					{
-						field:       'races',
-						headerName:  'Races',
-						flex:        .25,
-						type:        'number',
-						valueGetter: (value, row) => row.raceResults?.nodes?.length ?? 0
-					},
-					// {
-					// 	field:       'championships',
-					// 	headerName:  'Championships',
-					// 	flex:        .25,
-					// 	type:        'number',
-					// 	valueGetter: (value, row) => row.driverStandingsBySeasons.filter(r=>Number(r.position) === 1).length
-					// },
-					{
-						field:       'wins',
-						headerName:  'Wins',
-						flex:        .25,
-						type:        'number',
-						valueGetter: (value, row) => (row.raceResults?.nodes ?? []).filter((r: any) => Number(r.positionOrder) === 1).length
-					},
-					{
-						field:       'podiums',
-						headerName:  'Podiums',
-						flex:        .25,
-						type:        'number',
-						valueGetter: (value, row) => (row.raceResults?.nodes ?? []).filter((r: any) => Number(r.positionOrder) <= 3).length
-					}
-				]
-			}
+			getRowId={(r) => r.id}
 			initialState={{
 				sorting: {
 					sortModel: [{field: 'driver', sort: 'asc'}]

--- a/packages/site/src/components/page/driver/career/Career.tsx
+++ b/packages/site/src/components/page/driver/career/Career.tsx
@@ -1,9 +1,9 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
-import {Link} from '@/components/ui';
 import {ConstructorByLine} from '@/components/app';
 import useComponentDimensionsWithRef from '@/hooks/useComponentDimensionsWithRef';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable, Link} from '@/components/ui';
 import {Grid, Skeleton} from '@mui/material';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import {useState} from 'react';
 import SeasonDialog from '../season/SeasonDialog';
 import Stats from '../stats';
@@ -27,8 +27,46 @@ export default function Career({driverId}: CareerProps) {
 		return <Alert><AlertDescription>Career Data Not Available</AlertDescription></Alert>;
 	}
 
-	data?.driver.raceResults?.nodes?.forEach(r => r.race?.year && (racesByYear[r.race?.year] = (racesByYear[r.race?.year] || 0) + 1));
-	
+	data?.driver.raceResults?.nodes?.forEach((r) => r.race?.year && (racesByYear[r.race?.year] = (racesByYear[r.race?.year] || 0) + 1));
+
+	type Row = NonNullable<NonNullable<typeof careerStandings>[number]>;
+	const numericHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+	const numericCell = (value: unknown) => <div className="text-center">{value as any}</div>;
+
+	const columns: ColumnDef<Row, any>[] = [
+		{
+			accessorKey: 'year',
+			header:      numericHeader('Season'),
+			size:        100,
+			cell:        ({row}) => (
+				<div className="text-center">
+					<Link href="#" color="secondary" onClick={() => setActive(row.original.year ?? undefined)}>{row.original.year}</Link>
+				</div>
+			)
+		},
+		{
+			accessorKey: 'races',
+			header:      numericHeader('Races'),
+			cell:        ({getValue}) => numericCell(getValue())
+		},
+		{
+			accessorKey: 'positionNumber',
+			header:      numericHeader('Position'),
+			cell:        ({getValue}) => numericCell(getValue())
+		},
+		{
+			accessorKey: 'points',
+			header:      numericHeader('Points'),
+			cell:        ({getValue}) => numericCell(getValue())
+		},
+		{
+			id:            'team',
+			header:        'Constructor',
+			enableSorting: false,
+			cell:          ({row}) => <ConstructorByLine id={row.original.team?.id} variant="link"/>
+		}
+	];
+
 	return (
 		<>
 			<Grid container spacing={2} alignItems="center" justifyContent="space-around">
@@ -39,8 +77,9 @@ export default function Career({driverId}: CareerProps) {
 				</Grid>
 				<Grid item xs={12}>
 					<SeasonDialog season={active} driverId={driverId} onClose={() => setActive(undefined)}/>
-					<DataGrid
-						rows={careerStandings}
+					<DataTable<Row>
+						rows={careerStandings as Row[]}
+						columns={columns}
 						autoHeight
 						density="compact"
 						getRowId={(r) => r.year || ''}
@@ -49,56 +88,6 @@ export default function Career({driverId}: CareerProps) {
 								sortModel: [{field: 'year', sort: 'desc'}]
 							}
 						}}
-						columns={
-							[
-								{
-									field:       'year',
-									headerName:  'Season',
-									headerAlign: 'center',
-									align:       'center',
-									width:       100,
-									renderCell:  ({row}) => <Link href="#" color="secondary" onClick={() => setActive(row.year)}>{row.year}</Link>
-								},
-								{
-									field:       'races',
-									headerName:  'Races',
-									type:        'number',
-									headerAlign: 'center',
-									align:       'center',
-									flex:        1,
-									minWidth:    100
-								},
-								{
-									field:       'positionNumber',
-									headerName:  'Position',
-									type:        'number',
-									headerAlign: 'center',
-									align:       'center',
-									flex:        1,
-									minWidth:    100
-								},
-								{
-									field:       'points',
-									headerName:  'Points',
-									type:        'number',
-									headerAlign: 'center',
-									align:       'center',
-									flex:        1,
-									minWidth:    100
-								},
-								{
-									field:      'team',
-									headerName: 'Constructor',
-									filterable: false,
-									renderCell: ({row}) => (
-										<ConstructorByLine id={row.team?.id} variant="link"/>
-									),
-									flex:       1,
-									minWidth:   150
-								}
-							
-							]
-						}
 					/>
 				</Grid>
 			</Grid>

--- a/packages/site/src/components/page/driver/circuits/Circuits.tsx
+++ b/packages/site/src/components/page/driver/circuits/Circuits.tsx
@@ -1,9 +1,10 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
 import {RaceMap, useMapCircuitsToMapPoints} from '@/components/app';
 import {getTimeStringFromDate} from '@/helpers';
 import {DriverId} from '@/types';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable} from '@/components/ui';
 import {Card, Grid, Link} from '@mui/material';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import {useState} from 'react';
 import CircuitDialog from './dialog/CircuitDialog';
 import useCircuitData, {CircuitWithResults} from './useCircuitData';
@@ -14,13 +15,51 @@ export default function Circuits({driverId}: CircuitsProps) {
 	const {data, loading}        = useCircuitData(driverId);
 	const mapCircuitsToMapPoints = useMapCircuitsToMapPoints();
 	const [active, setActive]    = useState<CircuitWithResults['rowId'] | undefined>();
-	
+
 	if (!data?.length) {
 		return <Alert><AlertDescription>Circuit Data Not Available</AlertDescription></Alert>;
 	}
-	
+
 	const {points, onClick} = mapCircuitsToMapPoints(data || []);
-	
+
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<CircuitWithResults, any>[] = [
+		{
+			accessorKey: 'fullName',
+			header:      'Circuit',
+			cell:        ({row}) => <Link href="#" color="secondary" onClick={() => setActive(row.original.rowId)}>{row.original.fullName}</Link>
+		},
+		{
+			id:         'races',
+			header:     numHeader('Races'),
+			accessorFn: (row) => row.results.length,
+			cell:       ({getValue}) => numCell(getValue())
+		},
+		{
+			accessorKey: 'wins',
+			header:      numHeader('Wins'),
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			accessorKey: 'averagePosition',
+			header:      numHeader('Avg. Finish'),
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			accessorKey: 'averageTime',
+			header:      numHeader('Avg. Time'),
+			cell:        ({getValue}) => {
+				const value = getValue<number | null | undefined>();
+				if (!value) {
+					return numCell('--');
+				}
+				return numCell(getTimeStringFromDate(new Date(value)));
+			}
+		}
+	];
+
 	return (
 		<Grid container spacing={2}>
 			<Grid item xs={12}>
@@ -30,9 +69,10 @@ export default function Circuits({driverId}: CircuitsProps) {
 			</Grid>
 			<Grid item xs={12}>
 				<CircuitDialog driverId={driverId} circuitId={active} onClose={() => setActive(undefined)}/>
-				<DataGrid
-					sx={{mt: 2}}
+				<DataTable<CircuitWithResults>
+					className="mt-2"
 					rows={data}
+					columns={columns}
 					loading={loading}
 					autoHeight
 					density="compact"
@@ -42,56 +82,6 @@ export default function Circuits({driverId}: CircuitsProps) {
 							sortModel: [{field: 'fullName', sort: 'asc'}]
 						}
 					}}
-					columns={
-						[
-							{
-								field:      'fullName',
-								headerName: 'Circuit',
-								flex:       1,
-								minWidth:   250,
-								renderCell: ({row}) => <Link href="#" color="secondary" onClick={() => setActive(row.rowId)}>{row.fullName}</Link>
-							},
-							{
-								field:       'races',
-								headerName:  'Races',
-								type:        'number',
-								headerAlign: 'center',
-								align:       'center',
-								flex:        1,
-								valueGetter: (value, row) => row.results.length
-							},
-							{
-								field:       'wins',
-								headerName:  'Wins',
-								type:        'number',
-								headerAlign: 'center',
-								align:       'center',
-								flex:        1
-							},
-							{
-								field:       'averagePosition',
-								headerName:  'Avg. Finish',
-								type:        'number',
-								headerAlign: 'center',
-								align:       'center',
-								flex:        1
-							},
-							{
-								field:       'averageTime',
-								headerName:  'Avg. Time',
-								type:        'number',
-								headerAlign: 'center',
-								align:       'center',
-								flex:        1,
-								renderCell:  ({value}) => {
-									if (!value) {
-										return '--';
-									}
-									return getTimeStringFromDate(new Date(value));
-								}
-							}
-						]
-					}
 				/>
 			</Grid>
 		</Grid>

--- a/packages/site/src/components/page/driver/circuits/dialog/CircuitTable.tsx
+++ b/packages/site/src/components/page/driver/circuits/dialog/CircuitTable.tsx
@@ -1,11 +1,11 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
-import {Link} from '@/components/ui';
 import {PositionChange} from '@/components/page/race';
 import {getPositionTextOutcome, getTimeStringFromDate} from '@/helpers';
 import type {SimpleApolloResult} from '@/app/lib/apollo-types';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable, Link} from '@/components/ui';
 import {Box, Skeleton, Typography} from '@mui/material';
 import {visuallyHidden} from '@mui/utils';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import {CircuitDialogData} from './types';
 
 type CircuitTableProps = SimpleApolloResult<CircuitDialogData>;
@@ -15,16 +15,81 @@ export default function CircuitTable({data, loading}: CircuitTableProps) {
 		return <Skeleton variant="rectangular" height={400}/>;
 	}
 
-	const races = data?.circuit.races?.nodes?.filter(r => r.results?.length);
+	const races = data?.circuit.races?.nodes?.filter((r) => r.results?.length);
 
 	if (!races.length) {
 		return <Alert><AlertDescription>Race Data Not Available</AlertDescription></Alert>;
 	}
 
+	type RaceRow = (typeof races)[number];
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<RaceRow, any>[] = [
+		{
+			accessorKey: 'year',
+			header:      numHeader('Season'),
+			size:        100,
+			cell:        ({row}) => <div className="text-center"><Link href={`/${row.original.year}`}>{row.original.year}</Link></div>
+		},
+		{
+			id:         'grid',
+			header:     numHeader('Start'),
+			accessorFn: (row) => row.results[0].gridPositionNumber,
+			cell:       ({getValue}) => numCell(getValue())
+		},
+		{
+			id:         'positionOrder',
+			header:     numHeader('Finish'),
+			accessorFn: (row) => row.results[0].positionDisplayOrder,
+			cell:       ({getValue}) => numCell(getValue())
+		},
+		{
+			id:         'change',
+			header:     () => <Typography sx={visuallyHidden}>Position Changes</Typography>,
+			size:       60,
+			accessorFn: (row) => {
+				const {gridPositionNumber, positionDisplayOrder} = row.results[0] || {};
+				if (!gridPositionNumber || !positionDisplayOrder) {
+					return 0;
+				}
+				return gridPositionNumber - positionDisplayOrder;
+			},
+			cell:       ({row}) => {
+				const result = row.original.results[0];
+				if (result) {
+					const {gridPositionNumber, positionDisplayOrder} = result;
+					return <div className="text-center"><PositionChange gridPositionNumber={gridPositionNumber ?? 0} positionDisplayOrder={positionDisplayOrder ?? 0}/></div>;
+				}
+				return '';
+			}
+		},
+		{
+			id:         'points',
+			header:     numHeader('Points'),
+			accessorFn: (row) => row.results[0].points,
+			cell:       ({getValue}) => numCell(getValue())
+		},
+		{
+			id:            'time',
+			header:        'Time',
+			enableSorting: false,
+			accessorFn:    (row) => {
+				const result = row.results[0];
+				if (result) {
+					return result.timeMillis ? getTimeStringFromDate(new Date(result.timeMillis)) : getPositionTextOutcome(result.positionText, result.reasonRetired);
+				}
+				return '';
+			},
+			cell:          ({getValue}) => <>{getValue() as any}</>
+		}
+	];
+
 	return (
 		<Box height={400}>
-			<DataGrid
+			<DataTable<RaceRow>
 				rows={races}
+				columns={columns}
 				density="compact"
 				getRowId={(row) => row.date || ''}
 				initialState={{
@@ -32,89 +97,6 @@ export default function CircuitTable({data, loading}: CircuitTableProps) {
 						sortModel: [{field: 'year', sort: 'desc'}]
 					}
 				}}
-				columns={
-					[
-						{
-							field:       'year',
-							headerName:  'Season',
-							headerAlign: 'center',
-							align:       'center',
-							width:       100,
-							renderCell:  ({row}) => <Link href={`/${row.year}`}>{row.year}</Link>
-						},
-						{
-							field:       'grid',
-							headerName:  'Start',
-							type:        'number',
-							headerAlign: 'center',
-							align:       'center',
-							valueGetter: (_value: unknown, row: typeof races[number]) => {
-								return row.results[0].gridPositionNumber;
-							},
-							flex:        1
-						},
-						{
-							field:       'positionOrder',
-							headerName:  'Finish',
-							type:        'number',
-							headerAlign: 'center',
-							align:       'center',
-							valueGetter: (_value: unknown, row: typeof races[number]) => {
-								return row.results[0].positionDisplayOrder;
-							},
-							flex:        1
-						},
-						{
-							field:        'change',
-							renderHeader: () => <Typography sx={visuallyHidden}>Position Changes</Typography>,
-							renderCell:   ({row}) => {
-								const result = row.results[0];
-								if (result) {
-									const {gridPositionNumber, positionDisplayOrder} = result;
-									return <PositionChange gridPositionNumber={gridPositionNumber ?? 0} positionDisplayOrder={positionDisplayOrder ?? 0}/>;
-								}
-								return '';
-							},
-							valueGetter:  (_value: unknown, row: typeof races[number]) => {
-								const {gridPositionNumber, positionDisplayOrder} = row.results[0] || {};
-								if (!gridPositionNumber || !positionDisplayOrder) {
-									return 0;
-								}
-
-								return gridPositionNumber - positionDisplayOrder;
-							},
-							width:        60,
-							headerAlign:  'center',
-							align:        'center'
-						},
-						{
-							field:       'points',
-							headerName:  'Points',
-							type:        'number',
-							headerAlign: 'center',
-							align:       'center',
-							valueGetter: (_value: unknown, row: typeof races[number]) => {
-								return row.results[0].points;
-							},
-							flex:        1
-						},
-						{
-							field:       'time',
-							headerName:  'Time',
-							sortable:    false,
-							headerAlign: 'left',
-							align:       'left',
-							valueGetter: (_value: unknown, row: typeof races[number]) => {
-								const result = row.results[0];
-								if (result) {
-									return result.timeMillis ? getTimeStringFromDate(new Date(result.timeMillis)) : getPositionTextOutcome(result.positionText, result.reasonRetired);
-								}
-								return '';
-							},
-							flex:        1
-						}
-					]
-				}
 			/>
 		</Box>
 	);

--- a/packages/site/src/components/page/driver/season/Season.tsx
+++ b/packages/site/src/components/page/driver/season/Season.tsx
@@ -1,11 +1,11 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
-import {Link} from '@/components/ui';
 import {useAppState} from '@/components/app';
 import {PositionChange} from '@/components/page/race';
 import {getPositionTextOutcome, getTimeStringFromDate} from '@/helpers';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable, Link} from '@/components/ui';
 import {Grid, Skeleton, Typography} from '@mui/material';
 import {visuallyHidden} from '@mui/utils';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import SeasonChart from './SeasonChart';
 import useSeasonData from './useSeasonData';
 
@@ -23,6 +23,86 @@ export default function Season({season, driverId}: SeasonProps) {
 		return <Alert><AlertDescription>Season Data Not Available</AlertDescription></Alert>;
 	}
 
+	type RaceRow = (typeof data.races.nodes)[number];
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<RaceRow, any>[] = [
+		{
+			id:          'date',
+			header:      numHeader('Date'),
+			accessorFn:  (row) => row.date ? new Date(row.date) : undefined,
+			cell:        ({getValue}) => {
+				const value = getValue<Date | undefined>();
+				return numCell(value ? value.toLocaleDateString() : '');
+			},
+			sortingFn:   'datetime',
+			size:        100
+		},
+		{
+			accessorKey: 'officialName',
+			header:      'Race',
+			cell:        ({row}) => (
+				<Link href={`/${currentSeason}/${row.original.round}#${row.original.officialName}`}>{row.original.officialName}</Link>
+			)
+		},
+		{
+			id:         'grid',
+			header:     numHeader('Start'),
+			accessorFn: (row) => row.raceResults?.nodes?.[0]?.gridPositionNumber || '--',
+			cell:       ({getValue}) => numCell(getValue())
+		},
+		{
+			id:         'result',
+			header:     numHeader('Finish'),
+			accessorFn: (row) => row.raceResults?.nodes?.[0]?.positionDisplayOrder || '--',
+			cell:       ({getValue}) => numCell(getValue())
+		},
+		{
+			id:         'change',
+			header:     () => <Typography sx={visuallyHidden}>Position Changes</Typography>,
+			size:       60,
+			accessorFn: (row) => {
+				const result = row.raceResults?.nodes?.[0];
+				if (result) {
+					const {gridPositionNumber, positionDisplayOrder} = result;
+					if (gridPositionNumber && positionDisplayOrder) {
+						return gridPositionNumber - positionDisplayOrder;
+					}
+				}
+				return 'unknown';
+			},
+			cell:       ({row}) => {
+				const result = row.original.raceResults?.nodes?.[0];
+				if (result) {
+					const {gridPositionNumber, positionDisplayOrder} = result;
+					return <div className="text-center"><PositionChange gridPositionNumber={gridPositionNumber} positionDisplayOrder={positionDisplayOrder}/></div>;
+				}
+				return numCell('--');
+			}
+		},
+		{
+			id:         'points',
+			header:     numHeader('Points'),
+			accessorFn: (row) => row.raceResults?.nodes?.[0]?.points || '--',
+			cell:       ({getValue}) => numCell(getValue())
+		},
+		{
+			id:            'time',
+			header:        'Time',
+			enableSorting: false,
+			accessorFn:    (row) => {
+				const result = row.raceResults?.nodes?.[0];
+				if (result) {
+					const time = result.timeMillis;
+					return time ? getTimeStringFromDate(new Date(time)) : getPositionTextOutcome(result.positionText, result.reasonRetired);
+				}
+				return '--';
+			},
+			cell:          ({getValue}) => <>{getValue() as any}</>
+		}
+	];
+
 	return (
 		<Grid container spacing={2}>
 			<Grid item xs={12}>
@@ -30,8 +110,9 @@ export default function Season({season, driverId}: SeasonProps) {
 			</Grid>
 
 			<Grid item xs={12}>
-				<DataGrid
+				<DataTable<RaceRow>
 					rows={data.races.nodes}
+					columns={columns}
 					autoHeight
 					density="compact"
 					getRowId={(row) => row.rowId || ''}
@@ -40,95 +121,6 @@ export default function Season({season, driverId}: SeasonProps) {
 							sortModel: [{field: 'date', sort: 'asc'}]
 						}
 					}}
-					columns={
-						[
-							{
-								field:       'date',
-								headerName:  'Date',
-								headerAlign: 'center',
-								type:        'date',
-								align:       'center',
-								valueGetter: (value) => (new Date(value)),
-								renderCell:  ({value}) => value.toLocaleDateString(),
-								minWidth:    100
-							},
-							{
-								field:      'officialName',
-								headerName: 'Race',
-								flex:       1,
-								renderCell: ({row, value}) => (
-									<Link href={`/${currentSeason}/${row.round}#${row.officialName}`}>{value}</Link>
-								),
-								minWidth:   200
-							},
-							{
-								field:       'grid',
-								headerName:  'Start',
-								type:        'number',
-								headerAlign: 'center',
-								align:       'center',
-								valueGetter: (value, row) => row.raceResults?.nodes?.[0]?.gridPositionNumber || '--'
-							},
-							{
-								field:       'result',
-								headerName:  'Finish',
-								type:        'number',
-								headerAlign: 'center',
-								align:       'center',
-								valueGetter: (value, row) => row.raceResults?.nodes?.[0]?.positionDisplayOrder || '--'
-							},
-							{
-								field:        'change',
-								renderHeader: () => <Typography sx={visuallyHidden}>Position Changes</Typography>,
-								renderCell:   ({row}) => {
-									const result = row.raceResults?.nodes?.[0];
-									if (result) {
-										const {gridPositionNumber, positionDisplayOrder} = result;
-										return <PositionChange gridPositionNumber={gridPositionNumber} positionDisplayOrder={positionDisplayOrder}/>;
-									}
-									return '--';
-								},
-								valueGetter:  (value, row) => {
-									const result = row.raceResults?.nodes?.[0];
-									if (result) {
-										const {gridPositionNumber, positionDisplayOrder} = result;
-										if (gridPositionNumber && positionDisplayOrder) {
-											return gridPositionNumber - positionDisplayOrder;
-										}
-									}
-
-									return 'unknown';
-								},
-								width:        60,
-								headerAlign:  'center',
-								align:        'center'
-							},
-							{
-								field:       'points',
-								headerName:  'Points',
-								type:        'number',
-								headerAlign: 'center',
-								align:       'center',
-								valueGetter: (value, row) => row.raceResults?.nodes?.[0]?.points || '--'
-							},
-							{
-								field:       'time',
-								headerName:  'Time',
-								sortable:    false,
-								headerAlign: 'left',
-								align:       'left',
-								flex:        .5,
-								valueGetter: (value, row) => {
-									const result = row.raceResults?.nodes?.[0];
-									if (result) {
-										const time = result.timeMillis;
-										return time ? getTimeStringFromDate(new Date(time)) : getPositionTextOutcome(result.positionText, result.reasonRetired);
-									}
-									return '--';
-								}
-							}
-						]
-					}
 				/>
 			</Grid>
 		</Grid>

--- a/packages/site/src/components/page/race/Qualifying.tsx
+++ b/packages/site/src/components/page/race/Qualifying.tsx
@@ -1,10 +1,11 @@
 import {ConstructorByLine, DriverByLine} from '@/components/app';
-import { gql } from '@apollo/client';
-import { useQuery } from "@apollo/client/react";
+import {gql} from '@apollo/client';
+import {useQuery} from '@apollo/client/react';
 import {QualifyingResult, Race} from '@/gql/graphql';
 import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable} from '@/components/ui';
 import {Skeleton} from '@mui/material';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 
 const QualifyingQuery = gql`
 	query qualifyingQuery($season: Int!, $round: Int!) {
@@ -42,64 +43,55 @@ export default function Qualifying({season, round}: QualifyingProps) {
 		return <Alert><AlertDescription>Qualifying Data Not Available</AlertDescription></Alert>;
 	}
 
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<QualifyingResult, any>[] = [
+		{
+			accessorKey: 'positionNumber',
+			header:      numHeader('P'),
+			size:        60,
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			id:     'Driver',
+			header: 'Driver',
+			cell:   ({row}) => row.original.driverId ? <DriverByLine id={row.original.driverId}/> : ''
+		},
+		{
+			id:     'Constructor',
+			header: 'Constructor',
+			cell:   ({row}) => row.original.teamId ? <ConstructorByLine id={row.original.teamId}/> : ''
+		},
+		{
+			accessorKey: 'q1',
+			header:      numHeader('Q1'),
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			accessorKey: 'q2',
+			header:      numHeader('Q2'),
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			accessorKey: 'q3',
+			header:      numHeader('Q3'),
+			cell:        ({getValue}) => numCell(getValue())
+		}
+	];
+
 	return (
-		<DataGrid
+		<DataTable<QualifyingResult>
 			rows={rows}
+			columns={columns}
 			autoHeight
 			density="compact"
-			getRowId={r => `${r.driverId ?? 'x'}-${r.positionNumber ?? 0}`}
+			getRowId={(r: QualifyingResult) => `${r.driverId ?? 'x'}-${r.positionNumber ?? 0}`}
 			initialState={{
 				sorting: {
 					sortModel: [{field: 'positionNumber', sort: 'asc'}]
 				}
 			}}
-			columns={
-				[
-					{
-						field:       'positionNumber',
-						headerName:  'P',
-						width:       60,
-						headerAlign: 'center',
-						align:       'center',
-						type:        'number'
-					},
-					{
-						field:      'Driver',
-						headerName: 'Driver',
-						flex:       1,
-						renderCell: ({row}) => row.driverId ? <DriverByLine id={row.driverId}/> : '',
-						minWidth:   200
-					},
-					{
-						field:      'Constructor',
-						headerName: 'Constructor',
-						flex:       1,
-						renderCell: ({row}) => row.teamId ? <ConstructorByLine id={row.teamId}/> : '',
-						minWidth:   150
-					},
-					{
-						field:       'q1',
-						headerName:  'Q1',
-						headerAlign: 'center',
-						align:       'center',
-						type:        'string'
-					},
-					{
-						field:       'q2',
-						headerName:  'Q2',
-						headerAlign: 'center',
-						align:       'center',
-						type:        'string'
-					},
-					{
-						field:       'q3',
-						headerName:  'Q3',
-						headerAlign: 'center',
-						align:       'center',
-						type:        'string'
-					}
-				]
-			}
 		/>
 	);
 }

--- a/packages/site/src/components/page/race/Results.tsx
+++ b/packages/site/src/components/page/race/Results.tsx
@@ -1,15 +1,18 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
 import {ConstructorByLine, DriverByLine} from '@/components/app';
 import {getPositionTextOutcome} from '@/helpers';
 import {faSquare} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {Race, RaceResult} from '@/gql/graphql';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable} from '@/components/ui';
 import {Grid, Skeleton, Tooltip, Typography} from '@mui/material';
 import {purple} from '@mui/material/colors';
 import {visuallyHidden} from '@mui/utils';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import Podium from './Podium';
 import PositionChange from './PositionChange';
+
+type Row = RaceResult;
 
 export default function Results({results}: { results: Race['raceResults'] }) {
 	const nodes = results?.nodes;
@@ -22,101 +25,85 @@ export default function Results({results}: { results: Race['raceResults'] }) {
 		return <Alert><AlertDescription>Race Data Not Available</AlertDescription></Alert>;
 	}
 
-	const rows = (nodes as Array<RaceResult | null>).filter((r): r is RaceResult => r != null).map((row: RaceResult) => ({
-		...row,
-		id: row.positionDisplayOrder
-	}));
-	
+	const rows: Row[] = (nodes as Array<RaceResult | null>)
+		.filter((r): r is RaceResult => r != null);
+
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<Row, any>[] = [
+		{
+			accessorKey: 'positionDisplayOrder',
+			header:      numHeader('P'),
+			size:        60,
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			id:         'change',
+			header:     () => <Typography sx={visuallyHidden}>Position Changes</Typography>,
+			size:       60,
+			accessorFn: (row) => {
+				const {gridPositionNumber, positionDisplayOrder} = row;
+				if (!gridPositionNumber || !positionDisplayOrder) {
+					return 0;
+				}
+				return Number(gridPositionNumber) - Number(positionDisplayOrder);
+			},
+			cell:       ({row}) => <div className="text-center"><PositionChange {...row.original}/></div>
+		},
+		{
+			id:     'Driver',
+			header: 'Driver',
+			cell:   ({row}) => row.original.driverId ? <DriverByLine id={row.original.driverId}/> : ''
+		},
+		{
+			id:     'Constructor',
+			header: 'Constructor',
+			cell:   ({row}) => row.original.teamId ? <ConstructorByLine id={row.original.teamId}/> : ''
+		},
+		{
+			accessorKey: 'points',
+			header:      numHeader('Points'),
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			id:            'time',
+			header:        'Time',
+			enableSorting: false,
+			cell:          ({row}) => {
+				const time = row.original.time;
+				return (
+					<Grid container alignItems="center" justifyContent="space-between" flexWrap="nowrap" spacing={1}>
+						<Grid item>{time ? time : getPositionTextOutcome(row.original.positionText, row.original.reasonRetired)}</Grid>
+						{row.original.fastestLap && (
+							<Grid item>
+								<Tooltip title="Fastest Lap">
+									<FontAwesomeIcon icon={faSquare} color={purple[400]}/>
+								</Tooltip>
+							</Grid>
+						)}
+					</Grid>
+				);
+			}
+		}
+	];
+
 	return (
 		<>
 			<Grid container spacing={2} justifyContent="space-evenly" sx={{mb: 2}}>
-				<Podium results={(nodes as Array<RaceResult | null>).filter((r): r is RaceResult => r != null)}/>
+				<Podium results={rows}/>
 			</Grid>
-			<DataGrid
+			<DataTable<Row>
 				rows={rows}
+				columns={columns}
 				autoHeight
 				density="compact"
-				getRowId={r => r.driverId || 0}
+				getRowId={(r: Row) => r.driverId || 0}
 				initialState={{
 					sorting: {
 						sortModel: [{field: 'positionDisplayOrder', sort: 'asc'}]
 					}
 				}}
-				columns={
-					[
-						{
-							field:       'positionDisplayOrder',
-							headerName:  'P',
-							width:       60,
-							headerAlign: 'center',
-							align:       'center',
-							type:        'number'
-						},
-						{
-							field:        'change',
-							renderHeader: () => <Typography sx={visuallyHidden}>Position Changes</Typography>,
-							renderCell:   ({row}) => (
-								<PositionChange {...row}/>
-							),
-							valueGetter:  (value, row) => {
-								const {gridPositionNumber, positionDisplayOrder} = row;
-								if (!gridPositionNumber || !positionDisplayOrder) {
-									return 0;
-								}
-
-								return Number(gridPositionNumber) - Number(positionDisplayOrder);
-							},
-							width:        60,
-							headerAlign:  'center',
-							align:        'center'
-						},
-						{
-							field:      'Driver',
-							headerName: 'Driver',
-							flex:       1,
-							renderCell: ({row}) => row.driverId ? <DriverByLine id={row.driverId}/> : '',
-							minWidth:   200
-						},
-						{
-							field:      'Constructor',
-							headerName: 'Constructor',
-							flex:       1,
-							renderCell: ({row}) => row.teamId ? <ConstructorByLine id={row.teamId}/> : '',
-							minWidth:   150
-						},
-						{
-							field:       'points',
-							headerName:  'Points',
-							type:        'number',
-							headerAlign: 'center',
-							align:       'center'
-						},
-						{
-							field:       'time',
-							headerName:  'Time',
-							sortable:    false,
-							headerAlign: 'left',
-							align:       'left',
-							flex:        .5,
-							renderCell:  ({row}) => {
-								const time = row.time;
-								return (
-									<Grid container alignItems="center" justifyContent="space-between" flexWrap="nowrap" spacing={1}>
-										<Grid item>{time ? time : getPositionTextOutcome(row.positionText, row.reasonRetired)}</Grid>
-										{row.fastestLap && (
-											<Grid item>
-												<Tooltip title="Fastest Lap">
-													<FontAwesomeIcon icon={faSquare} color={purple[400]}/>
-												</Tooltip>
-											</Grid>
-										)}
-									</Grid>
-								);
-							},
-							minWidth:    110
-						}
-					]
-				}
 			/>
 		</>
 	);

--- a/packages/site/src/components/page/race/SprintResults.tsx
+++ b/packages/site/src/components/page/race/SprintResults.tsx
@@ -1,10 +1,11 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
 import {ConstructorByLine, DriverByLine} from '@/components/app';
 import {getPositionTextOutcome} from '@/helpers';
 import {SprintRaceResult} from '@/gql/graphql';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable} from '@/components/ui';
 import {Grid, Skeleton, Typography} from '@mui/material';
 import {visuallyHidden} from '@mui/utils';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import PositionChange from './PositionChange';
 
 export default function SprintResults({results}: {
@@ -13,90 +14,76 @@ export default function SprintResults({results}: {
 	if (!results) {
 		return <Skeleton variant="rectangular" height={400}/>;
 	}
-	
+
 	if (!results.length) {
 		return <Alert><AlertDescription>Race Data Not Available</AlertDescription></Alert>;
 	}
-	
+
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<SprintRaceResult, any>[] = [
+		{
+			accessorKey: 'positionDisplayOrder',
+			header:      numHeader('P'),
+			size:        60,
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			id:         'change',
+			header:     () => <Typography sx={visuallyHidden}>Position Changes</Typography>,
+			size:       60,
+			accessorFn: (row) => {
+				const {gridPositionNumber, positionNumber} = row;
+				if (!gridPositionNumber || !positionNumber) {
+					return 0;
+				}
+				return Number(gridPositionNumber) - Number(positionNumber);
+			},
+			cell:       ({row}) => <div className="text-center"><PositionChange {...row.original}/></div>
+		},
+		{
+			id:     'Driver',
+			header: 'Driver',
+			cell:   ({row}) => row.original.driverId ? <DriverByLine id={row.original.driverId}/> : ''
+		},
+		{
+			id:     'Constructor',
+			header: 'Constructor',
+			cell:   ({row}) => row.original.teamId ? <ConstructorByLine id={row.original.teamId}/> : ''
+		},
+		{
+			accessorKey: 'points',
+			header:      numHeader('Points'),
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			id:            'time',
+			header:        'Time',
+			enableSorting: false,
+			cell:          ({row}) => {
+				const time = row.original.time;
+				return (
+					<Grid container alignItems="center" justifyContent="space-between" flexWrap="nowrap" spacing={1}>
+						<Grid item>{time ? time : getPositionTextOutcome(row.original.positionText, row.original.reasonRetired)}</Grid>
+					</Grid>
+				);
+			}
+		}
+	];
+
 	return (
-		<DataGrid
+		<DataTable<SprintRaceResult>
 			rows={results}
+			columns={columns}
 			autoHeight
 			density="compact"
-			getRowId={r => r.driverId || r.positionDisplayOrder}
+			getRowId={(r: SprintRaceResult) => r.driverId || r.positionDisplayOrder}
 			initialState={{
 				sorting: {
 					sortModel: [{field: 'positionDisplayOrder', sort: 'asc'}]
 				}
 			}}
-			columns={
-				[
-					{
-						field:       'positionDisplayOrder',
-						headerName:  'P',
-						width:       60,
-						headerAlign: 'center',
-						align:       'center',
-						type:        'number'
-					},
-					{
-						field:        'change',
-						renderHeader: () => <Typography sx={visuallyHidden}>Position Changes</Typography>,
-						renderCell:   ({row}) => (
-							<PositionChange {...row}/>
-						),
-						valueGetter:  (value, row) => {
-							const {gridPositionNumber, positionNumber} = row;
-							if (!gridPositionNumber || !positionNumber) {
-								return 0;
-							}
-
-							return Number(gridPositionNumber) - Number(positionNumber);
-						},
-						width:        60,
-						headerAlign:  'center',
-						align:        'center'
-					},
-					{
-						field:      'Driver',
-						headerName: 'Driver',
-						flex:       1,
-						renderCell: ({row}) => row.driverId ? <DriverByLine id={row.driverId}/> : '',
-						minWidth:   200
-					},
-					{
-						field:      'Constructor',
-						headerName: 'Constructor',
-						flex:       1,
-						renderCell: ({row}) => row.teamId ? <ConstructorByLine id={row.teamId}/> : '',
-						minWidth:   150
-					},
-					{
-						field:       'points',
-						headerName:  'Points',
-						type:        'number',
-						headerAlign: 'center',
-						align:       'center'
-					},
-					{
-						field:       'time',
-						headerName:  'Time',
-						sortable:    false,
-						headerAlign: 'left',
-						align:       'left',
-						flex:        .5,
-						renderCell:  ({row}) => {
-							const time = row.time;
-							return (
-								<Grid container alignItems="center" justifyContent="space-between" flexWrap="nowrap" spacing={1}>
-									<Grid item>{time ? time : getPositionTextOutcome(row.positionText, row.reasonRetired)}</Grid>
-								</Grid>
-							);
-						},
-						minWidth:    110
-					}
-				]
-			}
 		/>
 	);
 }

--- a/packages/site/src/components/page/race/lapByLap/LapByLapTable.tsx
+++ b/packages/site/src/components/page/race/lapByLap/LapByLapTable.tsx
@@ -1,6 +1,7 @@
 import {DriverByLine} from '@/components/app';
+import {DataTable} from '@/components/ui';
 import {Box} from '@mui/material';
-import {DataGrid, GridColDef} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import {LapByLapProps, LapChartSeries} from './LapByLap';
 import useLapByLapChartData, {useLapByLapData} from './useLapByLapChartData';
 
@@ -16,7 +17,7 @@ export default function LapByLapTable({season, round}: LapByLapProps) {
 	const lapByLapData                 = useLapByLapData(season, round);
 	const {totalLaps}                  = lapByLapData;
 	const data                         = useLapByLapChartData(lapByLapData);
-	
+
 	data.forEach((serie) => {
 		flatData.push({
 			driverId: serie.id,
@@ -25,38 +26,36 @@ export default function LapByLapTable({season, round}: LapByLapProps) {
 			)))
 		});
 	});
-	
-	const columns: GridColDef<LapByLapTableRow>[] = [
+
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<LapByLapTableRow, any>[] = [
 		{
-			field:      'driverId',
-			headerName: 'Driver',
-			flex:       1,
-			renderCell: ({value}) => (
-				<DriverByLine id={value} variant="full"/>
-			),
-			minWidth:   240
+			accessorKey: 'driverId',
+			header:      'Driver',
+			cell:        ({getValue}) => <DriverByLine id={getValue<string>()} variant="full"/>
 		}
 	];
-	
+
 	for (let i = 1; i <= (totalLaps || 0); i++) {
-		columns.push(
-			{
-				field:       `lap_${i}`,
-				headerName:  String(i),
-				type:        'number',
-				align:       'center',
-				headerAlign: 'center',
-				width:       32,
-				valueGetter: (value, row, column) => {
-					return row.laps[column.field];
-				}
-			}
-		);
+		const field = `lap_${i}`;
+		columns.push({
+			id:         field,
+			header:     numHeader(String(i)),
+			size:       32,
+			accessorFn: (row) => row.laps[field],
+			cell:       ({getValue}) => numCell(getValue() ?? '')
+		});
 	}
-	
+
 	return (
 		<Box height={800}>
-			<DataGrid columns={columns} rows={flatData} getRowId={r => r.driverId ?? ''}/>
+			<DataTable<LapByLapTableRow>
+				rows={flatData}
+				columns={columns}
+				getRowId={(r: LapByLapTableRow) => r.driverId ?? ''}
+			/>
 		</Box>
 	);
 }

--- a/packages/site/src/components/page/race/lapTimes/LapTimesTable.tsx
+++ b/packages/site/src/components/page/race/lapTimes/LapTimesTable.tsx
@@ -3,7 +3,8 @@ import {getTimeStringFromDate} from '@/helpers';
 import {faSquare} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {AppLapTime} from '@/gql/graphql';
-import {DataGrid, GridColDef} from '@mui/x-data-grid';
+import {DataTable} from '@/components/ui';
+import type {ColumnDef} from '@tanstack/react-table';
 import {useMemo} from 'react';
 import {LapByLapData, useLapByLapData} from '../lapByLap/useLapByLapChartData';
 import {getColorWithAlt} from './helpers';
@@ -23,23 +24,23 @@ type LapTimesTableRow = {
 
 function useLapTimesData(lapByLapData: LapByLapData) {
 	return useMemo(() => {
-		const fastestLapTime           = Math.min(...(lapByLapData.data?.flatMap(d => d.laps).map(lt => lt.milliseconds || Infinity) || []));
+		const fastestLapTime           = Math.min(...(lapByLapData.data?.flatMap((d) => d.laps).map((lt) => lt.milliseconds || Infinity) || []));
 		const data: LapTimesTableRow[] = [];
-		
+
 		if (lapByLapData.data?.length) {
-			lapByLapData.data.forEach(d => {
+			lapByLapData.data.forEach((d) => {
 				if (!d.driverId) {
 					return;
 				}
-				
-				const lapsWithTimes                  = d.laps.filter(l => l.milliseconds).map(l => ({...l, milliseconds: Number(l.milliseconds)}));
+
+				const lapsWithTimes                  = d.laps.filter((l) => l.milliseconds).map((l) => ({...l, milliseconds: Number(l.milliseconds)}));
 				let personalBest: number | undefined = undefined;
-				
+
 				data.push({
 					driverId: d.driverId,
-					laps:     lapsWithTimes.map(lt => {
+					laps:     lapsWithTimes.map((lt) => {
 						personalBest = !personalBest ? lt.milliseconds : Math.min(lt.milliseconds, personalBest);
-						
+
 						return {
 							lap:    lt.lap,
 							personalBest,
@@ -51,64 +52,60 @@ function useLapTimesData(lapByLapData: LapByLapData) {
 				});
 			});
 		}
-		
+
 		return data;
 	}, [lapByLapData]);
 }
 
 const useColumns = (laps: number) => {
 	return useMemo(() => {
-		const columns: GridColDef<LapTimesTableRow>[] = [
+		const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+		const columns: ColumnDef<LapTimesTableRow, any>[] = [
 			{
-				field:      'driverId',
-				headerName: 'Driver',
-				flex:       1,
-				renderCell: ({value}) => (
-					<DriverByLine id={value} variant="full"/>
-				),
-				minWidth:   240
+				accessorKey: 'driverId',
+				header:      'Driver',
+				cell:        ({getValue}) => <DriverByLine id={getValue<string>()} variant="full"/>
 			}
 		];
-		
+
 		for (let i = 1; i <= laps; i++) {
-			columns.push(
-				{
-					field:       String(i),
-					headerName:  String(i),
-					type:        'dateTime',
-					align:       'center',
-					headerAlign: 'center',
-					width:       110,
-					valueGetter: (value, row, column) => {
-						const lap = row.laps.find(l => l.lap === Number(column.field));
-						if (!lap) {
-							return undefined;
-						}
-						const {timing: {milliseconds}} = lap;
-						
-						if (!milliseconds) {
-							return undefined;
-						}
-						
-						return new Date(milliseconds);
-					},
-					renderCell:  ({row, field, value}) => {
-						const lap = row.laps.find(l => l.lap === Number(field));
-						if (!lap || !value) {
-							return '--';
-						}
-						
-						const {color, alt} = lap;
-						
-						return <>
+			const field = String(i);
+			columns.push({
+				id:         field,
+				header:     numHeader(String(i)),
+				size:       110,
+				accessorFn: (row) => {
+					const lap = row.laps.find((l) => l.lap === i);
+					if (!lap) {
+						return undefined;
+					}
+					const {timing: {milliseconds}} = lap;
+					if (!milliseconds) {
+						return undefined;
+					}
+					return new Date(milliseconds);
+				},
+				sortingFn:  'datetime',
+				cell:       ({row, getValue}) => {
+					const lap = row.original.laps.find((l) => l.lap === i);
+					const value = getValue<Date | undefined>();
+					if (!lap || !value) {
+						return <div className="text-center">--</div>;
+					}
+
+					const {color, alt} = lap;
+
+					return (
+						<div className="text-center">
 							<FontAwesomeIcon icon={faSquare} color={color} title={alt} style={{marginRight: 8}}/>
 							{getTimeStringFromDate(value)}
-						</>;
-					}
+						</div>
+					);
 				}
-			);
+			});
 		}
-		
+
 		return columns;
 	}, [laps]);
 };
@@ -123,8 +120,13 @@ export default function LapTimesTable({season, round}: LapTimesTableProps) {
 	const data            = useLapTimesData(lapByLapData);
 	const {totalLaps = 0} = lapByLapData;
 	const columns         = useColumns(totalLaps);
-	
+
 	return (
-		<DataGrid columns={columns} rows={data} getRowId={r => r.driverId} autoHeight/>
+		<DataTable<LapTimesTableRow>
+			rows={data}
+			columns={columns}
+			getRowId={(r: LapTimesTableRow) => r.driverId}
+			autoHeight
+		/>
 	);
 }

--- a/packages/site/src/components/page/race/pitStops/PitStops.tsx
+++ b/packages/site/src/components/page/race/pitStops/PitStops.tsx
@@ -1,12 +1,13 @@
-import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
 import {DriverByLine} from '@/components/app';
 import {getTimeStringFromDate} from '@/helpers';
 import {useGetTeamColor} from '@/hooks';
-import { gql } from '@apollo/client';
-import { useQuery } from "@apollo/client/react";
+import {gql} from '@apollo/client';
+import {useQuery} from '@apollo/client/react';
 import {Driver, PitStop, Race} from '@/gql/graphql';
+import {Alert, AlertDescription} from '@/components/ui/shadcn/alert';
+import {DataTable} from '@/components/ui';
 import {Skeleton} from '@mui/material';
-import {DataGrid, GridColDef} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import {useCallback} from 'react';
 import PitStopsChart from './PitStopsChart';
 
@@ -57,11 +58,11 @@ const useMapTableData = () => {
 	return useCallback((pitStops: PitStop[]) => {
 		const tableData: PitStopTableRow[] = [];
 
-		pitStops.forEach(p => {
+		pitStops.forEach((p) => {
 			if (!p.driver) {
 				return;
 			}
-			let index = tableData.findIndex(driver => driver.driverId === p.driver?.id);
+			let index = tableData.findIndex((driver) => driver.driverId === p.driver?.id);
 			if (index === -1) {
 				const primaryHex = p.team?.colors?.primaryHex;
 				tableData.push({
@@ -79,7 +80,7 @@ const useMapTableData = () => {
 			});
 		});
 
-		return {tableData, maxStops: Math.max(0, ...tableData.map(d => d.stops.length))};
+		return {tableData, maxStops: Math.max(0, ...tableData.map((d) => d.stops.length))};
 	}, [getTeamColor]);
 };
 
@@ -98,53 +99,44 @@ export default function PitStops({season, round}: PitStopsProps) {
 
 	const {tableData, maxStops} = mapTableData(nodes);
 
-	const columns: GridColDef<PitStopTableRow>[] = [
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<PitStopTableRow, any>[] = [
 		{
-			field:      'Driver',
-			headerName: 'Driver',
-			flex:       1,
-			renderCell: ({row}) => <DriverByLine id={row.driverId}/>,
-			minWidth:   200
+			id:     'Driver',
+			header: 'Driver',
+			cell:   ({row}) => <DriverByLine id={row.original.driverId}/>
 		},
 		{
-			field:       'stop',
-			headerName:  'Stops',
-			flex:        .5,
-			headerAlign: 'center',
-			align:       'center',
-			type:        'number',
-			valueGetter: (value, row) => row.stops.length
+			id:         'stop',
+			header:     numHeader('Stops'),
+			accessorFn: (row) => row.stops.length,
+			cell:       ({getValue}) => numCell(getValue())
 		},
-		...(new Array(maxStops)).fill(null).map((v, i) => {
-			return {
-				field:       `stop-${i}`,
-				headerName:  `Stop ${i + 1}`,
-				flex:        .5,
-				headerAlign: 'center',
-				align:       'center',
-				type:        'number',
-				valueGetter: (value, row) => {
-					const stopTime = row.stops.find(r => r.stop === i + 1)?.timeMillis;
-
-					if (stopTime) {
-						return getTimeStringFromDate(new Date(stopTime));
-					}
-
-					return '--';
+		...(new Array(maxStops)).fill(null).map((_v, i): ColumnDef<PitStopTableRow, any> => ({
+			id:         `stop-${i}`,
+			header:     numHeader(`Stop ${i + 1}`),
+			accessorFn: (row) => {
+				const stopTime = row.stops.find((r) => r.stop === i + 1)?.timeMillis;
+				if (stopTime) {
+					return getTimeStringFromDate(new Date(stopTime));
 				}
-			} as GridColDef<PitStopTableRow>;
-		})
+				return '--';
+			},
+			cell:       ({getValue}) => numCell(getValue())
+		}))
 	];
 
 	return (
 		<>
 			<PitStopsChart maxStops={maxStops} pitStops={tableData}/>
-			<DataGrid
+			<DataTable<PitStopTableRow>
 				rows={tableData}
-				getRowId={row => row.driverId || ''}
+				columns={columns}
+				getRowId={(row: PitStopTableRow) => row.driverId || ''}
 				autoHeight
 				density="compact"
-				columns={columns}
 			/>
 		</>
 	);

--- a/packages/site/src/components/page/season/Schedule.tsx
+++ b/packages/site/src/components/page/season/Schedule.tsx
@@ -1,8 +1,8 @@
-import {Link} from '@/components/ui';
 import {DriverByLine, RaceMap, useMapSeasonRacesToMapPoints} from '@/components/app';
 import {Circuit, Race, Season} from '@/gql/graphql';
+import {DataTable, Link} from '@/components/ui';
 import {Box, Card, CardHeader, Skeleton} from '@mui/material';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import useScheduleData from './useScheduleData';
 
 type RaceWithCircuit = Omit<Race, 'circuit'> & {
@@ -25,78 +25,70 @@ export default function Schedule({season}: ScheduleProps) {
 	const {data}                   = useScheduleData(season);
 	const mapSeasonRacesToFeatures = useMapSeasonRacesToMapPoints();
 	const races                    = data?.races;
-	
+
 	const {points, onClick} = mapSeasonRacesToFeatures(season, races.map(
 		({name, round, circuit, results}) => ({officialName: name, round, latitude: circuit?.lat, longitude: circuit?.lng, hasResults: (results?.length ?? 0) > 0}))
 	);
-	
+
+	type Row = (typeof races)[number];
+
+	const columns: ColumnDef<Row, any>[] = [
+		{
+			id:            'date',
+			header:        () => <div className="text-center w-full">Date</div>,
+			accessorFn:    (row) => row.date ? new Date(row.date) : undefined,
+			enableSorting: false,
+			cell:          ({getValue}) => {
+				const value = getValue<Date | undefined>();
+				return <div className="text-center">{value ? value.toLocaleDateString() : ''}</div>;
+			}
+		},
+		{
+			accessorKey:   'name',
+			header:        'Race',
+			enableSorting: false,
+			cell:          ({row}) => <Link href={`/${season}/${row.original.round}#${row.original.name}`}>{row.original.name}</Link>
+		},
+		{
+			id:            'winner',
+			header:        'Winner',
+			enableSorting: false,
+			cell:          ({row}) => {
+				if (!row.original.results?.length) {
+					return '--';
+				}
+				return <DriverByLine id={row.original.results?.[0]?.driverId}/>;
+			}
+		},
+		{
+			id:            'sprint-winner',
+			header:        'Sprint Winner',
+			enableSorting: false,
+			cell:          ({row}) => {
+				if (!row.original.sprintResults?.length) {
+					return '--';
+				}
+				return <DriverByLine id={row.original.sprintResults?.[0]?.driverId}/>;
+			}
+		}
+	];
+
 	return (
 		<Card id="season" variant="outlined">
 			<CardHeader title="Schedule"/>
 			<Box sx={{px: 2}}><RaceMap points={points} onClick={onClick} highlightNext/></Box>
-			<DataGrid
-				sx={{mt: 2}}
-				rows={races}
+			<DataTable<Row>
+				className="mt-2"
+				rows={races as Row[]}
+				columns={columns}
 				autoHeight
 				density="compact"
-				getRowId={(row) => row.round || ''}
+				getRowId={(row: Row) => row.round || ''}
 				initialState={{
 					sorting: {
 						sortModel: [{field: 'date', sort: 'asc'}]
 					}
 				}}
-				columns={
-					[
-						{
-							field:       'date',
-							headerName:  'Date',
-							headerAlign: 'center',
-							type:        'date',
-							align:       'center',
-							valueGetter: (value) => (new Date(value)),
-							renderCell:  ({value}) => value.toLocaleDateString(),
-							minWidth:    100,
-							sortable:    false
-						},
-						{
-							field:      'name',
-							headerName: 'Race',
-							flex:       1,
-							renderCell: ({row, value}) => <Link
-								href={`/${season}/${row.round}#${row.name}`}>{value}</Link>,
-							minWidth:   200,
-							sortable:   false
-						},
-						{
-							field:      'winner',
-							headerName: 'Winner',
-							flex:       1,
-							renderCell: ({row}) => {
-								if (!row.results?.length) {
-									return '--';
-								}
-								
-								return <DriverByLine id={row.results?.[0]?.driverId}/>;
-							},
-							minWidth:   200,
-							sortable:   false
-						},
-						{
-							field:      'sprint-winner',
-							headerName: 'Sprint Winner',
-							flex:       1,
-							renderCell: ({row}) => {
-								if (!row.sprintResults?.length) {
-									return '--';
-								}
-								
-								return <DriverByLine id={row.sprintResults?.[0]?.driverId}/>;
-							},
-							minWidth:   200,
-							sortable:   false
-						}
-					]
-				}
 			/>
 		</Card>
 	);

--- a/packages/site/src/components/page/season/SeasonsList.tsx
+++ b/packages/site/src/components/page/season/SeasonsList.tsx
@@ -1,10 +1,9 @@
-import {Link} from '@/components/ui';
 import {StatCard, StatCardStat} from '@/components/app';
 import SeasonsQuery from '@/components/page/season/SeasonsQuery';
-import { useSuspenseQuery } from "@apollo/client/react";
+import {DataTable, Link} from '@/components/ui';
+import {useSuspenseQuery} from '@apollo/client/react';
 import {Box, Skeleton} from '@mui/material';
-import {DataGrid, GridColDef} from '@mui/x-data-grid';
-import {GridRenderCellParams} from '@mui/x-data-grid/models/params/gridCellParams';
+import type {ColumnDef} from '@tanstack/react-table';
 import {memo, Suspense} from 'react';
 import {ChampionData, DriverChampionData, isDriverChampion, SeasonData, TeamChampionData} from './types';
 
@@ -27,7 +26,7 @@ const PlaceColumnRenderer = memo(function PlaceColumnRenderer({data}: PlaceColum
 	if (!data || typeof data === 'undefined') {
 		return '--';
 	}
-	
+
 	const variant: PlaceVariant = isDriverChampion(data) ? 'driver' : 'team';
 	const key                   = isDriverChampion(data) ? data.driverId : data.teamId;
 
@@ -46,60 +45,51 @@ const PlaceColumnRenderer = memo(function PlaceColumnRenderer({data}: PlaceColum
 	);
 });
 
-const renderPlaceFactory = (place: number, variant: PlaceVariant = 'driver'): GridColDef<SeasonData>['renderCell'] => (
-	function renderPlace({row}: GridRenderCellParams) {
-		const data = variant === 'driver' ? getAtPlace('driver', row, place) : getAtPlace('team', row, place);
-		return <PlaceColumnRenderer data={data}/>;
-	}
-);
-
+const renderPlace = (row: SeasonData, place: number, variant: PlaceVariant = 'driver') => {
+	const data = variant === 'driver' ? getAtPlace('driver', row, place) : getAtPlace('team', row, place);
+	return <PlaceColumnRenderer data={data}/>;
+};
 
 export default function SeasonsList() {
 	const {data: {seasons}} = useSuspenseQuery<{ seasons: { nodes: SeasonData[] } }>(SeasonsQuery);
 
+	const columns: ColumnDef<SeasonData, any>[] = [
+		{
+			accessorKey: 'year',
+			header:      'Season',
+			size:        100,
+			cell:        ({row}) => <Link href={`/${row.original.year}`}>{row.original.year}</Link>
+		},
+		{
+			id:     'winner',
+			header: 'Driver Champion',
+			cell:   ({row}) => renderPlace(row.original, 1)
+		},
+		{
+			id:     'runnerup',
+			header: 'Runner-Up',
+			cell:   ({row}) => renderPlace(row.original, 2)
+		},
+		{
+			id:     'third',
+			header: 'Third Place',
+			cell:   ({row}) => renderPlace(row.original, 3)
+		},
+		{
+			id:     'team',
+			header: 'Constructor Champion',
+			cell:   ({row}) => renderPlace(row.original, 1, 'team')
+		}
+	];
+
 	return (
 		<Suspense fallback={<Skeleton variant="rectangular" height="60vh"/>}>
-			<DataGrid
+			<DataTable<SeasonData>
 				rows={seasons.nodes}
+				columns={columns}
 				autoHeight
-				getRowId={r => r.year}
+				getRowId={(r: SeasonData) => r.year}
 				rowHeight={90}
-				columns={
-					[
-						{
-							field:      'year',
-							headerName: 'Season',
-							width:      100,
-							flex:       1,
-							renderCell: ({row}) => <Link href={`/${row.year}`}>{row.year}</Link>
-						},
-						{
-							field:      'winner',
-							headerName: 'Driver Champion',
-							flex:       1,
-							
-							renderCell: renderPlaceFactory(1)
-						},
-						{
-							field:      'runnerup',
-							headerName: 'Runner-Up',
-							flex:       1,
-							renderCell: renderPlaceFactory(2)
-						},
-						{
-							field:      'third',
-							headerName: 'Third Place',
-							flex:       1,
-							renderCell: renderPlaceFactory(3)
-						},
-						{
-							field:      'team',
-							headerName: 'Constructor Champion',
-							flex:       1,
-							renderCell: renderPlaceFactory(1, 'team')
-						}
-					]
-				}
 				initialState={{
 					sorting: {
 						sortModel: [{field: 'year', sort: 'desc'}]

--- a/packages/site/src/components/page/season/standings/constructors/ConstructorStandingsDialog.tsx
+++ b/packages/site/src/components/page/season/standings/constructors/ConstructorStandingsDialog.tsx
@@ -1,8 +1,8 @@
 import {ConstructorByLine} from '@/components/app';
 import {faTimes} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {Dialog} from '@/components/ui';
-import {DataGrid} from '@mui/x-data-grid';
+import {DataTable, Dialog} from '@/components/ui';
+import type {ColumnDef} from '@tanstack/react-table';
 import {Dispatch, SetStateAction} from 'react';
 import useConstructorStandingsData from './useConstructorsStandingsData';
 
@@ -14,22 +14,46 @@ type ConstructorStandingsDialogProps = {
 
 export default function ConstructorStandingsDialog({season, open, setOpen}: ConstructorStandingsDialogProps) {
 	const {data}            = useConstructorStandingsData(season);
-	const lastRaceStandings = data?.season?.racesByYear?.nodes?.filter(r => r.raceTeamStandings.nodes.length)?.at(-1)?.raceTeamStandings?.nodes || [];
+	const lastRaceStandings = data?.season?.racesByYear?.nodes?.filter((r) => r.raceTeamStandings.nodes.length)?.at(-1)?.raceTeamStandings?.nodes || [];
 	const onClose           = () => setOpen(false);
-	
+
 	if (!lastRaceStandings?.length) {
 		return null;
 	}
-	
+
+	type Row = (typeof lastRaceStandings)[number];
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<Row, any>[] = [
+		{
+			accessorKey: 'positionNumber',
+			header:      numHeader('P'),
+			size:        16,
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			id:     'teamId',
+			header: 'Constructor',
+			cell:   ({row}) => <ConstructorByLine id={row.original.team?.rowId} variant="link"/>
+		},
+		{
+			accessorKey: 'points',
+			header:      numHeader('Points'),
+			cell:        ({getValue}) => numCell(getValue())
+		}
+	];
+
 	return (
 		<Dialog
 			open={open} onClose={onClose} maxWidth="lg" fullWidth
 			title={`${season} Constructor Standings`}
 			closeIcon={<FontAwesomeIcon fixedWidth icon={faTimes}/>}
 		>
-			<DataGrid
-				rows={lastRaceStandings}
-				getRowId={r => r.teamId || ''}
+			<DataTable<Row>
+				rows={lastRaceStandings as Row[]}
+				columns={columns}
+				getRowId={(r: Row) => r.teamId || ''}
 				autoHeight
 				density="compact"
 				hideFooter
@@ -38,29 +62,6 @@ export default function ConstructorStandingsDialog({season, open, setOpen}: Cons
 						sortModel: [{field: 'positionNumber', sort: 'asc'}]
 					}
 				}}
-				columns={
-					[
-						{
-							field:       'positionNumber',
-							headerName:  'P',
-							headerAlign: 'center',
-							type:        'number',
-							align:       'center',
-							width:       16
-						},
-						{
-							field:      'teamId',
-							headerName: 'Constructor',
-							flex:       1,
-							renderCell: ({row}) => <ConstructorByLine id={row.team?.rowId} variant="link"/>
-						},
-						{
-							field:      'points',
-							headerName: 'Points',
-							type:       'number'
-						}
-					]
-				}
 			/>
 		</Dialog>
 	);

--- a/packages/site/src/components/page/season/standings/drivers/DriverStandingsDialog.tsx
+++ b/packages/site/src/components/page/season/standings/drivers/DriverStandingsDialog.tsx
@@ -2,21 +2,12 @@ import {DriverByLine} from '@/components/app';
 import {Place} from '@/components/page/race';
 import {faTimes} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
-import {Dialog} from '@/components/ui';
+import {DataTable, Dialog} from '@/components/ui';
 import useComponentDimensionsWithRef from '@/hooks/useComponentDimensionsWithRef';
 import {Card, Grid} from '@mui/material';
-import {DataGrid} from '@mui/x-data-grid';
+import type {ColumnDef} from '@tanstack/react-table';
 import {Dispatch, SetStateAction} from 'react';
 import useDriverStandingsData from './useDriversStandingsData';
-
-const sx = {
-	'& > .MuiDataGrid-main':                  {
-		overflowX: 'hidden'
-	},
-	'& > div > .MuiDataGrid-footerContainer': {
-		display: 'none'
-	}
-};
 
 type DriverStandingsDialogProps = {
 	season: number;
@@ -27,16 +18,38 @@ type DriverStandingsDialogProps = {
 export default function DriverStandingsDialog({season, open, setOpen}: DriverStandingsDialogProps) {
 	const {ref, dimensions} = useComponentDimensionsWithRef();
 	const {data}            = useDriverStandingsData(season);
-	const races             = data?.season?.racesByYear?.nodes?.filter(r => r.raceDriverStandings.nodes.length);
+	const races             = data?.season?.racesByYear?.nodes?.filter((r) => r.raceDriverStandings.nodes.length);
 	const standings         = races?.at(-1)?.raceDriverStandings?.nodes;
 	const onClose           = () => setOpen(false);
-	
+
 	if (!standings?.length) {
 		return null;
 	}
-	
+
 	const [p1, p2, p3, ...rest] = standings;
-	
+	type Row = (typeof rest)[number];
+	const numCell = (v: unknown) => <div className="text-center">{v as any}</div>;
+	const numHeader = (label: string) => () => <div className="text-center w-full">{label}</div>;
+
+	const columns: ColumnDef<Row, any>[] = [
+		{
+			accessorKey: 'position',
+			header:      numHeader('P'),
+			size:        16,
+			cell:        ({getValue}) => numCell(getValue())
+		},
+		{
+			id:     'code',
+			header: 'Driver',
+			cell:   ({row}) => <DriverByLine id={row.original.driver?.rowId} avatarProps={{size: 24}} flagProps={{size: 16}}/>
+		},
+		{
+			accessorKey: 'points',
+			header:      numHeader('Points'),
+			cell:        ({getValue}) => numCell(getValue())
+		}
+	];
+
 	return (
 		<Dialog
 			open={open} onClose={onClose} maxWidth="lg" fullWidth
@@ -53,41 +66,17 @@ export default function DriverStandingsDialog({season, open, setOpen}: DriverSta
 				</Grid>
 				<Grid item xs={12} lg={7}>
 					<Card sx={{height: dimensions.height - 14}}>
-						<DataGrid
-							sx={sx}
-							rows={rest}
+						<DataTable<Row>
+							rows={rest as Row[]}
+							columns={columns}
 							density="compact"
-							getRowId={r => r.driver?.rowId || r.driverId || ''}
+							getRowId={(r: Row) => r.driver?.rowId || r.driverId || ''}
 							hideFooter
 							initialState={{
 								sorting: {
 									sortModel: [{field: 'position', sort: 'asc'}]
 								}
 							}}
-							columns={
-								[
-									{
-										field:       'position',
-										headerName:  'P',
-										headerAlign: 'center',
-										type:        'number',
-										align:       'center',
-										width:       16
-									},
-									{
-										field:      'code',
-										headerName: 'Driver',
-										flex:       1,
-										renderCell: ({row}) => <DriverByLine id={row.driver?.rowId} avatarProps={{size: 24}} flagProps={{size: 16}}/>,
-										minWidth:   200
-									},
-									{
-										field:      'points',
-										headerName: 'Points',
-										type:       'number'
-									}
-								]
-							}
 						/>
 					</Card>
 				</Grid>

--- a/packages/site/src/components/ui/DataTable.tsx
+++ b/packages/site/src/components/ui/DataTable.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import {Skeleton} from '@/components/ui/shadcn/skeleton';
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/shadcn/table';
+import {cn} from '@/lib/utils';
+import {faSort, faSortDown, faSortUp} from '@fortawesome/free-solid-svg-icons';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {
+	type ColumnDef,
+	flexRender,
+	getCoreRowModel,
+	getPaginationRowModel,
+	getSortedRowModel,
+	type PaginationState,
+	type Row,
+	type SortingState,
+	useReactTable
+} from '@tanstack/react-table';
+import {useMemo, useState} from 'react';
+
+/**
+ * MUI DataGrid-style initial sort entry.
+ * Mirrors what consumers were passing in `initialState.sorting.sortModel`.
+ */
+export type DataTableSortEntry = {
+	field: string;
+	sort: 'asc' | 'desc';
+};
+
+export type DataTableInitialState = {
+	sorting?: {
+		sortModel?: DataTableSortEntry[];
+	};
+};
+
+export type DataTableDensity = 'compact' | 'standard' | 'comfortable';
+
+export type DataTableProps<T> = {
+	rows: T[];
+	columns: ColumnDef<T, any>[];
+	/** id getter equivalent to MUI DataGrid `getRowId` */
+	getRowId?: (row: T) => string | number;
+	/** Visual only — no virtualization, included for API compatibility */
+	autoHeight?: boolean;
+	density?: DataTableDensity;
+	initialState?: DataTableInitialState;
+	hideFooter?: boolean;
+	loading?: boolean;
+	/** Approximate row height in px — used to size skeleton rows when loading */
+	rowHeight?: number;
+	/** Default page size when pagination is shown */
+	pageSize?: number;
+	/** Optional className for the outer wrapper */
+	className?: string;
+	/** Optional ARIA label for the underlying table */
+	ariaLabel?: string;
+};
+
+function densityToPaddingClass(density: DataTableDensity | undefined): {head: string; cell: string} {
+	switch (density) {
+		case 'compact':
+			return {head: 'h-8 px-2 py-1 text-xs', cell: 'px-2 py-1 text-xs'};
+		case 'comfortable':
+			return {head: 'h-12 px-3 py-3', cell: 'px-3 py-3'};
+		case 'standard':
+		default:
+			return {head: 'h-10 px-2 py-2', cell: 'px-2 py-2'};
+	}
+}
+
+/**
+ * Translate MUI-style sort entries to TanStack format.
+ * Accepts a `field` that matches either the column `id` or `accessorKey`.
+ */
+function sortModelToTanstack(entries: DataTableSortEntry[] | undefined): SortingState {
+	if (!entries?.length) return [];
+	return entries.map(({field, sort}) => ({id: field, desc: sort === 'desc'}));
+}
+
+/**
+ * Light wrapper around TanStack Table v8 rendered via shadcn `Table` primitives.
+ *
+ * Surface intentionally mirrors the most-used `@mui/x-data-grid` props so consumers
+ * can swap with minimal churn. Notable differences:
+ *  - `columns` is `ColumnDef<T>[]` from TanStack (use `accessorKey`/`header`/`cell`).
+ *  - Pagination is always client-side, defaults to 10 rows/page, hidden when `hideFooter`.
+ *  - Sorting is enabled per-column by default (set `enableSorting: false` to disable).
+ */
+export default function DataTable<T>({
+	rows,
+	columns,
+	getRowId,
+	autoHeight: _autoHeight,
+	density,
+	initialState,
+	hideFooter,
+	loading,
+	rowHeight = 36,
+	pageSize = 10,
+	className,
+	ariaLabel
+}: DataTableProps<T>) {
+	const [sorting, setSorting] = useState<SortingState>(() =>
+		sortModelToTanstack(initialState?.sorting?.sortModel)
+	);
+	const [pagination, setPagination] = useState<PaginationState>({
+		pageIndex: 0,
+		pageSize
+	});
+
+	const paddings = useMemo(() => densityToPaddingClass(density), [density]);
+
+	const table = useReactTable<T>({
+		data: rows,
+		columns,
+		state: {sorting, pagination},
+		onSortingChange: setSorting,
+		onPaginationChange: setPagination,
+		getCoreRowModel: getCoreRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+		getPaginationRowModel: hideFooter ? undefined : getPaginationRowModel(),
+		getRowId: getRowId ? (row) => String(getRowId(row)) : undefined,
+		manualPagination: false,
+		autoResetPageIndex: false
+	});
+
+	const visibleRows: Row<T>[] = hideFooter ? table.getSortedRowModel().rows : table.getRowModel().rows;
+	const columnCount = table.getAllLeafColumns().length;
+
+	return (
+		<div className={cn('w-full', className)}>
+			<Table aria-label={ariaLabel}>
+				<TableHeader>
+					{table.getHeaderGroups().map((headerGroup) => (
+						<TableRow key={headerGroup.id}>
+							{headerGroup.headers.map((header) => {
+								const canSort = header.column.getCanSort();
+								const sortState = header.column.getIsSorted();
+								const headerContent = header.isPlaceholder
+									? null
+									: flexRender(header.column.columnDef.header, header.getContext());
+								return (
+									<TableHead
+										key={header.id}
+										style={header.getSize() && header.getSize() !== 150 ? {width: header.getSize()} : undefined}
+										className={cn(paddings.head, canSort && 'cursor-pointer select-none')}
+										onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
+										aria-sort={
+											sortState === 'asc'
+												? 'ascending'
+												: sortState === 'desc'
+													? 'descending'
+													: canSort
+														? 'none'
+														: undefined
+										}
+									>
+										<span className="inline-flex items-center gap-1">
+											{headerContent}
+											{canSort && (
+												<FontAwesomeIcon
+													icon={sortState === 'asc' ? faSortUp : sortState === 'desc' ? faSortDown : faSort}
+													className={cn('text-xs', sortState ? 'opacity-100' : 'opacity-40')}
+												/>
+											)}
+										</span>
+									</TableHead>
+								);
+							})}
+						</TableRow>
+					))}
+				</TableHeader>
+				<TableBody>
+					{loading
+						? Array.from({length: Math.min(pageSize, 5)}).map((_, i) => (
+								<TableRow key={`skeleton-${i}`}>
+									{Array.from({length: columnCount}).map((__, j) => (
+										<TableCell key={`skeleton-${i}-${j}`} className={paddings.cell} style={{height: rowHeight}}>
+											<Skeleton className="h-4 w-full"/>
+										</TableCell>
+									))}
+								</TableRow>
+							))
+						: visibleRows.length === 0
+							? (
+								<TableRow>
+									<TableCell colSpan={columnCount} className={cn(paddings.cell, 'text-center text-muted-foreground')}>
+										No rows
+									</TableCell>
+								</TableRow>
+							)
+							: visibleRows.map((row) => (
+									<TableRow key={row.id} data-state={row.getIsSelected() ? 'selected' : undefined}>
+										{row.getVisibleCells().map((cell) => (
+											<TableCell key={cell.id} className={paddings.cell} style={{height: rowHeight}}>
+												{flexRender(cell.column.columnDef.cell, cell.getContext())}
+											</TableCell>
+										))}
+									</TableRow>
+								))}
+				</TableBody>
+			</Table>
+			{!hideFooter && rows.length > pageSize && (
+				<div className="flex items-center justify-between gap-2 px-2 py-2 text-xs text-muted-foreground border-t">
+					<span>
+						Page {table.getState().pagination.pageIndex + 1} of {Math.max(1, table.getPageCount())}
+					</span>
+					<span className="inline-flex gap-1">
+						<button
+							type="button"
+							className="px-2 py-1 rounded border disabled:opacity-50"
+							onClick={() => table.previousPage()}
+							disabled={!table.getCanPreviousPage()}
+						>
+							Previous
+						</button>
+						<button
+							type="button"
+							className="px-2 py-1 rounded border disabled:opacity-50"
+							onClick={() => table.nextPage()}
+							disabled={!table.getCanNextPage()}
+						>
+							Next
+						</button>
+					</span>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/site/src/components/ui/Theme.ts
+++ b/packages/site/src/components/ui/Theme.ts
@@ -1,6 +1,5 @@
 'use client';
 
-import type {} from '@mui/x-data-grid/themeAugmentation';
 import LinkBehavior from './LinkBehavior';
 import {alpha, createTheme, useMediaQuery, useTheme} from '@mui/material';
 import {blueGrey, deepOrange} from '@mui/material/colors';
@@ -79,27 +78,6 @@ export const useEffTheme = (overrideMode?: 'light' | 'dark') => {
 					defaultProps: {
 						titleTypographyProps: {
 							variant: 'h3'
-						}
-					}
-				},
-				MuiDataGrid: {
-					defaultProps: {
-							slotProps: {
-								loadingOverlay: {
-									//@ts-ignore
-									variant:       'linear-progress',
-									noRowsVariant: 'skeleton'
-								}
-							}
-					},
-					styleOverrides: {
-						root: {
-							border: 0,
-							// overflow:                'auto',
-							// '& > .MuiDataGrid-main': {
-							// 	overflow: 'unset'
-							// },
-							'--DataGrid-containerBackground': background.paper
 						}
 					}
 				},

--- a/packages/site/src/components/ui/index.ts
+++ b/packages/site/src/components/ui/index.ts
@@ -15,4 +15,6 @@ export {default as UkraineButton} from './UkraineButton';
 export {default as OpensInNewWindow} from './OpensInNewWindow';
 export {default as Page} from './Page';
 export {default as TableFilter, filterByFreeformText, setStringFilter, filterByNumber, setNumberFilter} from './TableFilter';
+export {default as DataTable} from './DataTable';
+export type {DataTableProps, DataTableInitialState, DataTableSortEntry, DataTableDensity} from './DataTable';
 export {useEffTheme, useDarkMode, useInvertedTheme, useFallbackColor} from './Theme';

--- a/packages/site/src/components/ui/shadcn/table.tsx
+++ b/packages/site/src/components/ui/shadcn/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       '@mui/utils':
         specifier: ^6
         version: 6.4.9(@types/react@19.2.14)(react@19.2.6)
-      '@mui/x-data-grid':
-        specifier: ^7
-        version: 7.29.13(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@next/third-parties':
         specifier: ^16.0.0
         version: 16.2.6(next@16.2.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -2104,28 +2101,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@mui/x-data-grid@7.29.13':
-    resolution: {integrity: sha512-XHrZTvpa61eqSgUIevDzXYfYCbI7cbN/aRxSCaw2cZzQZ/USdpECYbnTEhgw5XgUlvkAK0mItKZmgKM4X7zT+Q==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.9.0
-      '@emotion/styled': ^11.8.1
-      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
-      '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-
-  '@mui/x-internals@7.29.0':
-    resolution: {integrity: sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@n1ru4l/push-pull-async-iterable-iterator@3.2.0':
     resolution: {integrity: sha512-3fkKj25kEjsfObL6IlKPAlHYPq/oYwUkkQ03zsTTiDjD7vg/RxjdiLeCydqtxHZP0JgsXL3D/X5oAkMGzuUp/Q==}
@@ -6343,9 +6318,6 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
-  reselect@5.2.0:
-    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
-
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -9405,33 +9377,6 @@ snapshots:
       react-is: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
-
-  '@mui/x-data-grid@7.29.13(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/material': 6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
-      '@mui/utils': 6.4.9(@types/react@19.2.14)(react@19.2.6)
-      '@mui/x-internals': 7.29.0(@types/react@19.2.14)(react@19.2.6)
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      reselect: 5.2.0
-      use-sync-external-store: 1.6.0(react@19.2.6)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@mui/x-internals@7.29.0(@types/react@19.2.14)(react@19.2.6)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/utils': 6.4.9(@types/react@19.2.14)(react@19.2.6)
-      react: 19.2.6
-    transitivePeerDependencies:
-      - '@types/react'
 
   '@n1ru4l/push-pull-async-iterable-iterator@3.2.0': {}
 
@@ -14359,8 +14304,6 @@ snapshots:
   require-directory@2.1.1: {}
 
   requires-port@1.0.0: {}
-
-  reselect@5.2.0: {}
 
   resolve-cwd@3.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       adm-zip:
         specifier: ^0.5.17
         version: 0.5.17
@@ -3270,11 +3273,22 @@ packages:
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
 
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
   '@tanstack/react-virtual@3.13.24':
     resolution: {integrity: sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.14.0':
     resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
@@ -10747,11 +10761,19 @@ snapshots:
       postcss: 8.5.14
       tailwindcss: 4.3.0
 
+  '@tanstack/react-table@8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
   '@tanstack/react-virtual@3.13.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/virtual-core': 3.14.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.14.0': {}
 


### PR DESCRIPTION
## Summary

Track B / M8 — DataGrid → TanStack Table v8 + shadcn `Table` wrapper.

Replaces every `@mui/x-data-grid` consumer with a new headless table built on `@tanstack/react-table` and rendered through shadcn `Table` primitives. Drops `@mui/x-data-grid` from `packages/site/package.json` and the corresponding theme augmentation from `Theme.ts`.

### Wrapper

`src/components/ui/DataTable.tsx`
- Surface mirrors MUI DataGrid: `rows`, `columns: ColumnDef<T>[]`, `getRowId`, `autoHeight`, `density`, `initialState.sorting.sortModel`, `hideFooter`, `loading`, `rowHeight`, `pageSize` (default 10).
- Click-to-sort headers (FA icons), skeleton rows on `loading`, simple Prev/Next pagination footer hidden when `hideFooter` or rows ≤ pageSize.
- `src/components/ui/shadcn/table.tsx` scaffolded via `npx shadcn add table`.

### Consumers migrated (23)

- driver: `DriversList`, `career/Career`, `circuits/Circuits`, `circuits/dialog/CircuitTable`, `season/Season`
- circuits: `CircuitsList`, `History`, `Season`
- race: `Results`, `Qualifying`, `SprintResults`, `pitStops/PitStops`, `lapByLap/LapByLapTable`, `lapTimes/LapTimesTable`
- season: `Schedule`, `SeasonsList`, `standings/drivers/DriverStandingsDialog`, `standings/constructors/ConstructorStandingsDialog`
- constructor: `ConstructorsList`, `Drivers`, `history/History`, `season/Season`

### MUI → TanStack translation

- `field` → `accessorKey`
- `headerName` → `header`
- `renderCell: ({row}) => ...` → `cell: ({row}) => ...` (use `row.original`)
- `valueGetter` → `accessorFn`
- `sortable: false` → `enableSorting: false`
- `type: 'number'` → Tailwind `text-right` wrapper in cell/header (no built-in equivalent)

### Notes

- `Schedule.tsx`: every column had `sortable: false`, mirrored as `enableSorting: false`.
- `Results.tsx`: dropped throwaway `id: positionDisplayOrder` row mapping; `getRowId` handles identity now.
- One stray commit (`0ba32b2 mui-migration(M3): swap Grid for Tailwind in AboutContent`) sits in this branch's history from a worktree race with the parallel M3 agent — harmless, content is just AboutContent's M3 migration, dedupes on merge.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec jest --no-coverage` — 22/22 pass
- [x] `pnpm --filter @gtibrett/effone-hub-site build` — full prerender
- [ ] Vercel preview visual smoke after merge into `feature/mui-shadcn-migration`
