### PR TITLE
fix(site): prerender only the 2 most recent seasons (cut Neon transfer)

### DIFF
--- a/packages/site/src/app/[season]/page.tsx
+++ b/packages/site/src/app/[season]/page.tsx
@@ -1,21 +1,29 @@
 import type { Metadata } from 'next';
 
 import {
+	getAppSeasonState,
 	getConstructorStandings,
 	getDriverStandings,
 	getSeason,
 	getSeasonRaceSchedule,
 	getSeasonSchedule,
-	getSeasonStats,
-	getSeasons
+	getSeasonStats
 } from '../lib/cached-data';
 import SeasonContent from './SeasonContent';
 
 type Params = Promise<{ season: string }>;
 
+// Prerender only the two most recent seasons. Each season page fans out to 14
+// GraphQL queries (getSeasonStats alone fires 9), so prerendering the full
+// ~76-season F1 history cost ~1,000+ Neon queries on EVERY deploy — the
+// dominant data-transfer driver. Older seasons render on-demand (dynamicParams
+// defaults true) and cache via cacheLife('max').
 export async function generateStaticParams(): Promise<{ season: string }[]> {
-	const seasons = await getSeasons();
-	return seasons.map(({ year }) => ({ season: String(year) }));
+	const { seasons } = await getAppSeasonState();
+	return [...seasons]
+		.sort((a, b) => b - a)
+		.slice(0, 2)
+		.map(year => ({ season: String(year) }));
 }
 
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {


### PR DESCRIPTION
## What

Narrow `app/[season]/page.tsx` `generateStaticParams` from **all ~76 F1 seasons** to the **2 most recent**. Older seasons render on-demand (`dynamicParams` default) and cache via `cacheLife('max')`.

## Why

Neon flagged the project at **81.8%** of its monthly network-transfer allowance (~4.18 GB / ~5 GB). Investigation ([#53](https://github.com/gtibrett/effone-hub/issues/53)):

- Egress is on the **`main`** Neon branch (the `preview` Neon branch is an archived 18 MB one-off — a red herring).
- Every `next build` runs `generateStaticParams`. All entity routes were already narrowed to the current season **except** `[season]`, which prerendered every season in history.
- Each season page fans out to **14 GraphQL queries** (`getSeasonStats` alone fires 9) → ~**1,064 queries/build** → PostGraphile API → Neon. At ~120 deploys/month, this was the dominant transfer driver. API logs confirm a 100+ `POST /graphql` burst on every deploy.

## Impact

Removes ~74 season prerenders × 14 queries ≈ **1,036 queries/build** (~**124k/month**) off `main`. First hit of an older season now costs 14 queries once per cache lifetime instead of once per build.

## Verification

- `tsc --noEmit` on `packages/site`: clean.
- Build-time-only change; on-demand render is identical output to the prior prerender.

## Notes / follow-ups (tracked in #53)

- `pg_stat_statements` enabled on the Neon `preview` branch to attribute the remaining **runtime** egress.
- Routing Vercel **preview** builds at a Neon preview branch (instead of `main`) is a separate infra change — pending.

Refs #53
