### PR TITLE
fix(site): authenticate build/RSC API fetches via Trusted Sources OIDC

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -66,6 +66,7 @@
 		"@mui/x-charts": "^9.5.0",
 		"@mui/x-data-grid": "^9.5.0",
 		"@next/third-parties": "^16.2.9",
+		"@vercel/oidc": "^3.6.1",
 		"clsx": "^2.1.1",
 		"d3-shape": "^3.2.0",
 		"emoji-flags": "^1.3.0",

--- a/packages/site/src/app/lib/apollo-rsc.ts
+++ b/packages/site/src/app/lib/apollo-rsc.ts
@@ -6,6 +6,7 @@ import {
 	InMemoryCache,
 	registerApolloClient
 } from '@apollo/client-integration-nextjs';
+import { getVercelOidcToken } from '@vercel/oidc';
 
 const LOCAL_API_URL = 'http://localhost:4000/graphql';
 
@@ -23,13 +24,16 @@ function resolveApiUrl(): string {
 	return LOCAL_API_URL;
 }
 
-// api preview deployments are SSO-gated, so server-side (RSC / build-time)
-// fetches need the x-vercel-protection-bypass header. Wrap fetch to add it
-// per-request (reads env at call time, not at link construction).
-const serverFetch: typeof fetch = (input, init) => {
+// api preview deployments are SSO-gated. This site is a Trusted Source of the
+// api, so server-side (RSC / build-time) fetches authenticate with this
+// deployment's short-lived OIDC token via x-vercel-trusted-oidc-idp-token.
+// (Prior x-vercel-protection-bypass path failed: the secret lived under
+// VERCEL_AUTOMATION_BYPASS_SECRET — a reserved system var Vercel overwrites at
+// build — so it never matched the api's bypass token.)
+const serverFetch: typeof fetch = async (input, init) => {
 	const headers = new Headers(init?.headers);
-	const bypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
-	if (bypass) headers.set('x-vercel-protection-bypass', bypass);
+	const oidcToken = await getVercelOidcToken().catch(() => undefined);
+	if (oidcToken) headers.set('x-vercel-trusted-oidc-idp-token', oidcToken);
 	return fetch(input, { ...init, headers });
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@next/third-parties':
         specifier: ^16.2.9
         version: 16.2.9(next@16.2.9(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@vercel/oidc':
+        specifier: ^3.6.1
+        version: 3.6.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -3074,6 +3077,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@0.1.1':
+    resolution: {integrity: sha512-LMRMEai3Z+BODyxGcU9+KiWrS/UElNiOLKiNRfGNt2Vu3NTEmXgFeXG9wBfocAnTe5yJCX/DY6k3k7S/LkPp/g==}
+    engines: {node: '>= 18'}
+
+  '@vercel/oidc@3.6.1':
+    resolution: {integrity: sha512-8ipTFoiX3WBRrvXLjSrmgAiwtMDQk3EgSxe8N7v2rXBz39NBIIyoGXeVbJRoBcP8WEuVnvjvIQsggbGU7ZKrMw==}
+    engines: {node: '>= 20'}
+
   '@whatwg-node/disposablestack@0.0.6':
     resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
     engines: {node: '>=18.0.0'}
@@ -4929,6 +4943,10 @@ packages:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
 
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -5919,6 +5937,14 @@ packages:
       utf-8-validate:
         optional: true
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -5960,6 +5986,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zustand@5.0.14:
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
@@ -9225,6 +9254,21 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@0.1.1':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/oidc@3.6.1':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 0.1.1
+      jose: 5.10.0
+
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:
       '@whatwg-node/promise-helpers': 1.3.2
@@ -11338,6 +11382,8 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
+  os-paths@4.4.0: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -12317,6 +12363,15 @@ snapshots:
 
   ws@8.21.0: {}
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -12346,6 +12401,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@4.1.11: {}
 
   zustand@5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:


### PR DESCRIPTION
## Summary
Server-side (RSC / build-time prerender) fetches to the SSO-gated GraphQL API were returning **401**, breaking preview builds (`Failed to collect page data for /[season]/[round]`).

Root cause: the site sent `x-vercel-protection-bypass` using a value stored under `VERCEL_AUTOMATION_BYPASS_SECRET` — a **reserved Vercel system variable** that Vercel overwrites at build with the site's *own* bypass secret. So the header never carried the API's token and the API rejected it. (Verified: the stored token bypasses the API via `curl` → 405, but the build's request 401s.)

## Fix
Use Vercel **Trusted Sources**: attach this deployment's short-lived OIDC token (`@vercel/oidc` → `getVercelOidcToken()`) in the `x-vercel-trusted-oidc-idp-token` header on server-side API fetches. Falls through cleanly when no token is present (local dev → unprotected local API).

## Changes
- `packages/site/src/app/lib/apollo-rsc.ts` — `serverFetch` sends the OIDC token instead of the shadowed bypass secret.
- Add `@vercel/oidc` dependency.

## Requires (already done in Vercel)
- The **site** project is configured as a **Trusted Source** of the **API** project.

## Testing
- `tsc --noEmit` (site) → clean.
- Preview build on this branch is the real check — it must go green now that the OIDC header + Trusted Sources are both in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)