### PR TITLE
fix(cache): audit ingest invalidation, guard tag coverage with contract test

### DIFF
--- a/packages/site/src/app/api/cron/revalidate/route.ts
+++ b/packages/site/src/app/api/cron/revalidate/route.ts
@@ -11,9 +11,9 @@
  */
 import { revalidateTag } from 'next/cache';
 
-export const maxDuration = 10;
+import { INGEST_CACHE_TAGS } from '@/app/lib/cache-tags';
 
-const CACHE_TAGS = ['seasons', 'current-season', 'drivers', 'teams', 'circuits', 'races'] as const;
+export const maxDuration = 10;
 
 type RevalidateResult = {
 	status: 'ok' | 'unauthorized' | 'partial';
@@ -40,7 +40,7 @@ export async function POST(req: Request): Promise<Response> {
 
 	const revalidated: string[] = [];
 	const failed: Array<{ tag: string; error: string }> = [];
-	for (const tag of CACHE_TAGS) {
+	for (const tag of INGEST_CACHE_TAGS) {
 		try {
 			// 'max' matches the cacheLife profile the data fetchers use; tags only
 			// flip on the ~24×/year ingest, so longest-lived revalidation is correct.

--- a/packages/site/src/app/lib/cache-tags.test.ts
+++ b/packages/site/src/app/lib/cache-tags.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Contract test: every cached accessor in cached-data.ts must be invalidatable
+ * by the ingest cron. The revalidate route only fires the broad tags in
+ * INGEST_CACHE_TAGS, so a cacheTag() call without at least one broad tag means
+ * that entry silently survives ingests until cacheLife expiry — invisible to
+ * tsc, jest units, and next build. Source-level scan keeps the check free of
+ * next/cache + Apollo runtime mocking.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { INGEST_CACHE_TAGS } from './cache-tags';
+
+const stripComments = (source: string): string =>
+	source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+describe('cached-data.ts ingest invalidation contract', () => {
+	const source = stripComments(readFileSync(join(__dirname, 'cached-data.ts'), 'utf8'));
+
+	const useCacheCount = (source.match(/'use cache'/g) ?? []).length;
+	const cacheTagCalls = [...source.matchAll(/cacheTag\(([^)]*)\)/g)].map(m => m[1]);
+
+	test('file contains cached accessors', () => {
+		expect(useCacheCount).toBeGreaterThan(0);
+	});
+
+	test("every 'use cache' function declares exactly one cacheTag call", () => {
+		expect(cacheTagCalls).toHaveLength(useCacheCount);
+	});
+
+	test('every cacheTag call includes at least one ingest-revalidated broad tag', () => {
+		const broadTags = new Set<string>(INGEST_CACHE_TAGS);
+		const orphans = cacheTagCalls.filter(args => {
+			const literals = [...args.matchAll(/'([^']+)'/g)].map(m => m[1]);
+			return !literals.some(tag => broadTags.has(tag));
+		});
+		expect(orphans).toEqual([]);
+	});
+});

--- a/packages/site/src/app/lib/cache-tags.ts
+++ b/packages/site/src/app/lib/cache-tags.ts
@@ -1,0 +1,17 @@
+/**
+ * Broad cache tags fired by POST /api/cron/revalidate after each F1DB ingest
+ * (~24×/year). This is the ONLY invalidation path for Cache Components data:
+ * every cached accessor in `cached-data.ts` must include at least one of these
+ * in its cacheTag() call or its entries survive ingests until cacheLife expiry.
+ * Enforced by `cache-tags.test.ts`.
+ */
+export const INGEST_CACHE_TAGS = [
+	'seasons',
+	'current-season',
+	'drivers',
+	'teams',
+	'circuits',
+	'races'
+] as const;
+
+export type IngestCacheTag = (typeof INGEST_CACHE_TAGS)[number];

--- a/packages/site/src/app/lib/cached-data.ts
+++ b/packages/site/src/app/lib/cached-data.ts
@@ -2,9 +2,14 @@
  * Cached RSC data accessors.
  *
  * Each function is wrapped with `use cache` (Next.js 16 Cache Components)
- * + `cacheTag` so the daily ingest job can call `updateTag` to invalidate
- * the relevant slice when new data lands. See `pages/api/cron/ingest.ts`
- * for the invalidation side.
+ * + `cacheTag`. Invalidation: the ingest GitHub Action
+ * (`packages/api/scripts/run-ingest.ts`) POSTs `/api/cron/revalidate`
+ * (`app/api/cron/revalidate/route.ts`), which fires `revalidateTag` for the
+ * broad tags in `INGEST_CACHE_TAGS` (`./cache-tags.ts`) — nothing else ever
+ * revalidates. Every cacheTag() call here MUST therefore include at least one
+ * broad tag (enforced by `cache-tags.test.ts`). Entity-scoped tags
+ * (`driver:X`, `race:Y:R`, …) are additive future hooks for selective
+ * invalidation; today they are never fired on their own.
  *
  * NO try/catch around the queries: a thrown error must propagate so Next does
  * NOT cache it. Catching and returning a degraded fallback ([]/null/{}) under
@@ -254,6 +259,9 @@ const AppSeasonStateQuery = gql`
 
 export async function getAppSeasonState(): Promise<AppSeasonState> {
 	'use cache';
+	// 'hours' not 'max': lastSeason derives from the wall-clock year read
+	// below, which gets baked into the cached entry — hourly revalidation
+	// bounds the staleness window around New Year.
 	cacheLife('hours');
 	cacheTag('seasons', 'current-season');
 	const { data } = await getClient().query<{
@@ -724,7 +732,8 @@ const RaceFullDataQuery = gql`
 
 export async function getRaceFullData(season: number, round: number): Promise<Race | null> {
 	'use cache';
-	// ingest cron invalidates race-data tags when corrections land.
+	// invalidated via broad 'races' tag on ingest; race-data:* is a dormant
+	// hook for future per-race revalidation, nothing fires it today.
 	cacheLife('max');
 	cacheTag('races', `race:${season}:${round}`, `race-data:${season}:${round}`);
 	const { data } = await getClient().query<{ races: Race[] }>({


### PR DESCRIPTION
Closes #64

## Audit result

No stale-data bugs. All 36 cached accessors in `cached-data.ts` carry at least one of the 6 broad tags fired by the ingest cron, so every cache entry invalidates on every ingest. Full chain verified: GitHub Action → `packages/api/scripts/run-ingest.ts` POST → `app/api/cron/revalidate/route.ts` → `revalidateTag(tag, 'max')` × `INGEST_CACHE_TAGS`. A failed revalidate POST fails the workflow (`exitCode = 1`). The runtime zero-GraphQL gate already exists (`e2e/ssr/no-client-graphql.spec.ts`).

| Accessors | Broad tags | cacheLife | Invalidation |
|---|---|---|---|
| `getAppSeasonState`, `getCurrentSeason`, `getCurrentSeason{RaceParams,DriverIds,TeamIds,CircuitIds}` | `seasons`, `current-season` (+entity) | `hours` | ingest + hourly revalidate |
| `getSeasons`, `getPastSeasonYears`, `getSeason`, `getSeasonSchedule`, `getSeasonRaceSchedule`, standings ×2, `getSeasonStats` | `seasons` (+`races`/`drivers`/`teams`) | `max` | ingest |
| `getDrivers`, `getDriverRowIds`, `getDriver`, career/circuits/season/dialog/stats | `drivers` (+`driver:X`) | `max` | ingest |
| `getConstructors`, `getTeamRowIds`, `getTeam`, `getConstructorData/Season/SeasonStats` | `teams` (+`team:X`) | `max` | ingest |
| `getCircuits`, `getCircuitRowIds`, `getCircuitPageData`, `getCircuit` | `circuits` (+`circuit:X`) | `max` | ingest |
| `getAllRaces`, `getRace`, `getRaceFullData`, qualifying/pitStops/lapByLap/stats | `races` (+`race:S:R`, `race-data:S:R`) | `max` | ingest |

## Changes

- **New contract test** (`src/app/lib/cache-tags.test.ts`): extracts `INGEST_CACHE_TAGS` to `src/app/lib/cache-tags.ts` (the revalidate route now imports it) and scans `cached-data.ts` source, failing if any `cacheTag()` call lacks an ingest-fired broad tag or any `'use cache'` function omits `cacheTag`. This closes the audit's only real gap: an orphaned tag was previously invisible to tsc, jest, and `next build`.
- **Corrected stale comments** that misdescribed invalidation: the header claimed `updateTag` via a nonexistent `pages/api/cron/ingest.ts`; `getRaceFullData` claimed the cron fires `race-data:*` tags (they're dormant granular hooks — nothing fires them today).
- **Documented** why `getAppSeasonState` uses `cacheLife('hours')`: a wall-clock year read is baked into the cached entry; hourly revalidation bounds New-Year staleness.

## Verification

- `jest src/app/lib/cache-tags.test.ts` — 3/3 pass
- Mutation-tested the guard: stripped broad tags from the race accessors → test failed; reverted → green
- `tsc --noEmit` clean, `biome check` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)